### PR TITLE
ci: adopt central web-release.yml@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  id-token: write       # OIDC for build-provenance attestation
+  attestations: write   # write the provenance attestation
   packages: write
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,72 +1,15 @@
 name: Release
-
 on:
   push:
-    tags:
-      - 'v*'
-
+    tags: ['v*']
 permissions:
   contents: write
   packages: write
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          make_latest: true
-
-  docker:
-    runs-on: ubuntu-latest
-    needs: release
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: fjacquet/ci/.github/workflows/web-release.yml@v1
+    with:
+      node-version: "24"
+      publish-npm: false
+      publish-docker: true
+      build-dir: "dist"


### PR DESCRIPTION
Replaces the bespoke `release.yml` (custom GitHub Release + inline Docker push) with a one-line caller to the shared reusable workflow `fjacquet/ci/.github/workflows/web-release.yml@v1`.

- Tag-triggered on `v*` (unchanged)
- npm publish **off** (private package)
- Docker publish **on** (Dockerfile present) → ghcr.io
- CycloneDX **SBOM** now attached to each release centrally

🤖 Generated with [Claude Code](https://claude.com/claude-code)