### PR TITLE
feat: show expired hardware assets, extend bars to end-of-support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ File drop/pick
 Pure functions, fully unit-tested, no React dependencies.
 
 - **headerResolver** — normalises Dell CSV column headers across EN/FR/IT/DE using `HEADER_ALIASES`. Throws if no recognised headers are found.
-- **assetFilter** — keeps only `PRODUCT TYPE = HARDWARE` + `SERVICES STATUS = Active` rows that have a parseable `CONTRACT END DATE`. Multi-language value matching via `HARDWARE_VALUES` / `ACTIVE_VALUES`.
+- **assetFilter** — keeps `PRODUCT TYPE = HARDWARE` rows that have a parseable `CONTRACT END DATE` (falling back to `END OF STANDARD SUPPORT`), **regardless of `SERVICES STATUS`** — lapsed/`Ended` contracts are shown too. Multi-language hardware matching via `HARDWARE_VALUES`. Each `ParsedAsset` also carries `endOfSupport` and `barEnd` (= `contractEnd` while live, or `endOfSupport ?? contractEnd` once expired, i.e. `daysRemaining < 0`).
 - **dateParser** — handles two Dell date formats: `"July 23, 2026"` (US long form) and `"4yr, 3mo, 1d"` (age-from-today offset).
 - **assetGrouper** — groups `ParsedAsset[]` by `locationId → productName`, computes `daysRemaining`, sorts by `contractEnd` ascending.
 - **svarAdapter** — converts `LocationGroup[]` into the flat SVAR task array. Integer IDs are assigned sequentially. Three-level hierarchy: location task (`parent` unset) → product group task (`parent=locationId`) → asset task (`parent=productId`). Bar colour set via `contractStatusColor`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Required columns (any supported language):
 | Location ID | `LOCATION ID` | `ID D'EMPLACEMENT` |
 | Location Name | `LOCATION NAME` | `NOM DE L'EMPLACEMENT` |
 
-Only rows where `PRODUCT TYPE = HARDWARE` and `SERVICES STATUS = Active` with a valid contract end date are shown.
+Rows where `PRODUCT TYPE = HARDWARE` with a parseable contract end date are shown, **regardless of `SERVICES STATUS`** — assets whose contracts have lapsed appear too (rendered gray, with the bar extended to the end of standard support).
 
 ---
 
@@ -105,7 +105,7 @@ src/
 ├── engines/csv/          # Pure CSV pipeline (fully unit-tested)
 │   ├── headerResolver    # EN/FR/IT/DE column alias normalisation
 │   ├── dateParser        # "July 23, 2026" and "4yr, 3mo, 1d" → Date
-│   ├── assetFilter       # HARDWARE + Active + has contract date
+│   ├── assetFilter       # HARDWARE + parseable date (any contract status)
 │   ├── assetGrouper      # Group by location → product, sort by expiry
 │   └── svarAdapter       # Domain model → SVAR Gantt task array
 ├── components/

--- a/docs/superpowers/plans/2026-06-24-expired-asset-visibility.md
+++ b/docs/superpowers/plans/2026-06-24-expired-asset-visibility.md
@@ -1,0 +1,495 @@
+# Expired Asset Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show all hardware assets in the Gantt regardless of service-contract status, and draw each bar to its next actionable deadline (contract end while live, end-of-standard-support once lapsed).
+
+**Architecture:** Three sequential, independently-green changes to the pure CSV engine layer: (1) relax the `Active`-only filter; (2) add `endOfSupport`/`barEnd` to `ParsedAsset` and compute them; (3) consume `barEnd` in the SVAR adapter and grouper span while preserving the existing contract-end-based sort order. No React, store, or component changes; color logic is reused unchanged.
+
+**Tech Stack:** TypeScript (strict), Vitest (globals, no explicit imports), Biome (sole linter/formatter), React + SVAR Gantt (downstream consumers, untouched here).
+
+**Context / why:** A user's CSV has 14 VxRail hardware rows but only 2 reach the Gantt. Root cause: `isIncluded()` (`src/engines/csv/assetFilter.ts:39-40`) drops any row whose `SERVICES STATUS` isn't `Active`; 12 of the 14 are `Ended` (contracts lapsed Feb 1 2026). Lapsed-contract hardware is the highest-risk category and was hidden. See spec: `docs/superpowers/specs/2026-06-24-expired-asset-visibility-design.md`.
+
+**Branch:** Work continues on `feat/expired-asset-visibility` (already checked out; spec already committed there).
+
+## Global Constraints
+
+- **Coverage threshold:** Vitest enforces ≥ 75% lines/functions/branches/statements on the engine layer; `make test-coverage` must pass. Copied verbatim from CLAUDE.md.
+- **Biome only:** no ESLint. Suppress with `// biome-ignore lint/<rule>: <reason>` if ever needed.
+- **TypeScript strict mode:** no new `as any` (the only sanctioned one is the `CSSStyleDeclaration.zoom` property in `useExport.ts`, unrelated to this work).
+- **Tests use Vitest globals:** do NOT import `describe`/`it`/`expect`.
+- **Engine layer is pure functions, no React imports.**
+- **Every commit message must end with these two trailers** (verbatim):
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01PwjvYFwpYKQ3NvfnZtHtn2
+  ```
+- **Single-file test run:** `npx vitest run <path>`. Full gate: `make ci` (typecheck + lint + test-coverage + build).
+
+---
+
+### Task 1: Relax the status filter (show all hardware regardless of contract status)
+
+Drop the `SERVICES STATUS = Active` gate in `isIncluded()`. Keep the hardware-only gate and the parseable-date requirement. This alone makes lapsed assets appear (bars at contract end, auto-colored gray by the existing `daysRemaining < 0` branch).
+
+**Files:**
+- Modify: `src/engines/csv/assetFilter.ts` (import line 1; `isIncluded` lines 35-45)
+- Test: `src/engines/csv/__tests__/assetFilter.test.ts` (update lines 28-30 and 135-145)
+
+**Interfaces:**
+- Consumes: `HARDWARE_VALUES`, `type FieldMap` from `./headerResolver`; `parseContractDate` from `./dateParser`.
+- Produces: `isIncluded(raw: RawAsset): boolean` — unchanged signature; now returns `true` for hardware rows with a parseable date regardless of `servicesStatus`. `ACTIVE_VALUES` is no longer imported or referenced.
+
+- [ ] **Step 1: Update the failing tests in `assetFilter.test.ts`**
+
+Replace the existing `'excludes non-active status'` test (lines 28-30) with:
+
+```ts
+  it('includes non-active (ended) hardware', () => {
+    expect(isIncluded({ ...baseAsset, servicesStatus: 'Ended' })).toBe(true)
+  })
+```
+
+Replace the `filterAssets` test `'returns only parseable hardware/active assets'` (lines 136-145) with:
+
+```ts
+  it('returns all parseable hardware assets regardless of status', () => {
+    const raws: RawAsset[] = [
+      { ...baseAsset, assetId: 'KEEP' },
+      { ...baseAsset, assetId: 'SKIP_SW', productType: 'SOFTWARE' },
+      { ...baseAsset, assetId: 'ENDED', servicesStatus: 'Ended' },
+    ]
+    const parsed = filterAssets(raws)
+    expect(parsed).toHaveLength(2)
+    expect(parsed.map((p) => p.assetId).sort()).toEqual(['ENDED', 'KEEP'])
+  })
+```
+
+Leave the other tests (`excludes software assets`, `excludes missing contract end date`, `includes French active status (Actif)`) unchanged — they still pass.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/engines/csv/__tests__/assetFilter.test.ts`
+Expected: FAIL — `includes non-active (ended) hardware` expects `true` but current code returns `false`; the `filterAssets` test expects length 2 but gets 1.
+
+- [ ] **Step 3: Implement — drop the status gate**
+
+In `src/engines/csv/assetFilter.ts`, change the import on line 1 from:
+
+```ts
+import { ACTIVE_VALUES, HARDWARE_VALUES, type FieldMap } from './headerResolver'
+```
+to:
+```ts
+import { HARDWARE_VALUES, type FieldMap } from './headerResolver'
+```
+
+Replace the body of `isIncluded` (lines 35-45) with:
+
+```ts
+export function isIncluded(raw: RawAsset): boolean {
+  const typeUpper = raw.productType.toUpperCase()
+  if (!HARDWARE_VALUES.some((v) => v.toUpperCase() === typeUpper)) return false
+
+  const contractEnd =
+    parseContractDate(raw.contractEndDate) ?? parseContractDate(raw.endOfStandardSupport)
+  return contractEnd !== null
+}
+```
+
+Also update the JSDoc above `isIncluded` (lines 29-34): remove the `services status is Active` bullet.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/engines/csv/__tests__/assetFilter.test.ts`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Verify lint + typecheck clean (catches the removed import)**
+
+Run: `make lint && make typecheck`
+Expected: no errors (confirms `ACTIVE_VALUES` is no longer referenced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/engines/csv/assetFilter.ts src/engines/csv/__tests__/assetFilter.test.ts
+git commit  # message: "feat: show all hardware assets regardless of contract status" + required trailers
+```
+
+---
+
+### Task 2: Add `endOfSupport` and `barEnd` to `ParsedAsset`
+
+Introduce the data the rendering layer needs: the parsed end-of-standard-support date and the computed bar-end date (`contractEnd` while live; `endOfSupport ?? contractEnd` once lapsed). Adding these as **required** fields forces updates to the two test helpers that build `ParsedAsset` literals, so they stay compiling/green.
+
+**Files:**
+- Modify: `src/types/asset.ts` (`ParsedAsset` interface, lines 17-28)
+- Modify: `src/engines/csv/assetFilter.ts` (`toParsedAsset`, lines 51-73)
+- Test: `src/engines/csv/__tests__/assetFilter.test.ts` (add a `barEnd / endOfSupport` describe block)
+- Test helper: `src/engines/csv/__tests__/assetGrouper.test.ts` (`makeAsset`, lines 4-17)
+- Test helper: `src/engines/csv/__tests__/svarAdapter.test.ts` (`makeLocationGroup` asset literal, lines 18-28)
+
+**Interfaces:**
+- Produces on `ParsedAsset`:
+  - `endOfSupport: Date | null` — parsed `END OF STANDARD SUPPORT`, or `null` when absent/unparseable.
+  - `barEnd: Date` — `daysRemaining < 0 ? (endOfSupport ?? contractEnd) : contractEnd`.
+- Consumed by Task 3 (`svarAdapter`, `assetGrouper`).
+
+- [ ] **Step 1: Write the failing tests** (append to `assetFilter.test.ts`)
+
+```ts
+describe('barEnd / endOfSupport', () => {
+  const today = new Date(2025, 0, 1)
+
+  it('uses contractEnd as barEnd for a live contract', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'December 31, 2027', endOfStandardSupport: 'June 30, 2030' },
+      today,
+    )
+    expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
+    expect(parsed.endOfSupport?.getFullYear()).toBe(2030)
+  })
+
+  it('extends barEnd to endOfSupport for an expired contract', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'February 01, 2020', endOfStandardSupport: 'June 30, 2030' },
+      today,
+    )
+    expect(parsed.daysRemaining).toBeLessThan(0)
+    expect(parsed.barEnd.getFullYear()).toBe(2030)
+  })
+
+  it('falls back to contractEnd as barEnd when an expired contract has no endOfSupport', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'February 01, 2020', endOfStandardSupport: '' },
+      today,
+    )
+    expect(parsed.endOfSupport).toBeNull()
+    expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/engines/csv/__tests__/assetFilter.test.ts`
+Expected: FAIL — `parsed.barEnd` / `parsed.endOfSupport` are `undefined` (and TypeScript errors that the properties don't exist on `ParsedAsset`).
+
+- [ ] **Step 3: Add the fields to `ParsedAsset`** in `src/types/asset.ts`
+
+Insert after the `daysRemaining` field (after line 27):
+
+```ts
+  /** Parsed END OF STANDARD SUPPORT date, or null if absent/unparseable */
+  endOfSupport: Date | null
+  /** Bar end date: contractEnd while the contract is live, else endOfSupport ?? contractEnd */
+  barEnd: Date
+```
+
+- [ ] **Step 4: Compute the fields in `toParsedAsset`** (`src/engines/csv/assetFilter.ts`)
+
+In `toParsedAsset`, after the `daysRemaining` calculation (after line 60) and before the `return`, add:
+
+```ts
+  const endOfSupport = parseContractDate(raw.endOfStandardSupport)
+  const barEnd = daysRemaining < 0 ? (endOfSupport ?? contractEnd) : contractEnd
+```
+
+Add the two new fields to the returned object (after `daysRemaining,`):
+
+```ts
+    daysRemaining,
+    endOfSupport,
+    barEnd,
+```
+
+- [ ] **Step 5: Update the `makeAsset` helper** in `src/engines/csv/__tests__/assetGrouper.test.ts` so `barEnd` defaults to `contractEnd` (keeps existing grouper assertions valid after Task 3). Replace the function (lines 4-17) with:
+
+```ts
+function makeAsset(overrides: Partial<ParsedAsset> = {}): ParsedAsset {
+  const contractEnd = overrides.contractEnd ?? new Date(2027, 0, 1)
+  return {
+    assetId: 'A1',
+    productName: 'PowerEdge R740',
+    locationId: 'LOC001',
+    locationName: 'Main DC',
+    city: 'Geneva',
+    country: 'Switzerland',
+    installDate: new Date(2022, 0, 1),
+    daysRemaining: 730,
+    endOfSupport: null,
+    ...overrides,
+    contractEnd,
+    barEnd: overrides.barEnd ?? contractEnd,
+  }
+}
+```
+
+- [ ] **Step 6: Update the asset literal** in `src/engines/csv/__tests__/svarAdapter.test.ts` `makeLocationGroup` (the object at lines 18-28). Add the two fields after `daysRemaining: 730,`:
+
+```ts
+            daysRemaining: 730,
+            endOfSupport: null,
+            barEnd: new Date(2027, 0, 1),
+```
+
+- [ ] **Step 7: Run the affected test files to verify green**
+
+Run: `npx vitest run src/engines/csv/__tests__/assetFilter.test.ts src/engines/csv/__tests__/assetGrouper.test.ts src/engines/csv/__tests__/svarAdapter.test.ts`
+Expected: PASS (all three files; the new `barEnd / endOfSupport` tests pass, existing tests unchanged).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `make typecheck`
+Expected: no errors (all `ParsedAsset` literals now include the required fields).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/types/asset.ts src/engines/csv/assetFilter.ts \
+  src/engines/csv/__tests__/assetFilter.test.ts \
+  src/engines/csv/__tests__/assetGrouper.test.ts \
+  src/engines/csv/__tests__/svarAdapter.test.ts
+git commit  # message: "feat: compute barEnd/endOfSupport on ParsedAsset" + required trailers
+```
+
+---
+
+### Task 3: Draw `barEnd` in the adapter and extend the grouper span (sort still by contract end)
+
+Make the visible bars and summary spans use `barEnd`, while keeping the "most-urgent-first" ordering driven by contract-end dates (so overdue/expired groups stay at the top, not buried by their 2030 end-of-support span).
+
+**Files:**
+- Modify: `src/engines/csv/svarAdapter.ts` (asset-task push, line ~54)
+- Modify: `src/engines/csv/assetGrouper.ts` (full `groupAssets` rewrite of span + sort lines)
+- Modify: `src/types/asset.ts` (doc comments on `groupEnd` / `locationEnd`)
+- Test: `src/engines/csv/__tests__/svarAdapter.test.ts` (add a barEnd assertion test)
+- Test: `src/engines/csv/__tests__/assetGrouper.test.ts` (add span-vs-sort tests)
+
+**Interfaces:**
+- Consumes: `ParsedAsset.barEnd`, `ParsedAsset.contractEnd` (from Task 2).
+- Produces: `groupEnd` / `locationEnd` now equal the latest child `barEnd` (span); group/location ordering is by latest `contractEnd` (urgency). `toGanttData` leaf task `end` equals `asset.barEnd`.
+
+- [ ] **Step 1: Write the failing adapter test** — append to `svarAdapter.test.ts`:
+
+```ts
+  it('uses barEnd (not contractEnd) for the asset bar end', () => {
+    const group: LocationGroup = {
+      locationId: 'L1',
+      locationName: 'Main DC',
+      city: 'Geneva',
+      country: 'Switzerland',
+      locationStart: new Date(2022, 0, 1),
+      locationEnd: new Date(2030, 0, 1),
+      productGroups: [
+        {
+          productName: 'VxRail E660F',
+          groupStart: new Date(2022, 0, 1),
+          groupEnd: new Date(2030, 0, 1),
+          assets: [
+            {
+              assetId: 'EXP',
+              productName: 'VxRail E660F',
+              locationId: 'L1',
+              locationName: 'Main DC',
+              city: 'Geneva',
+              country: 'Switzerland',
+              installDate: new Date(2022, 0, 1),
+              contractEnd: new Date(2024, 0, 1),
+              daysRemaining: -100,
+              endOfSupport: new Date(2030, 0, 1),
+              barEnd: new Date(2030, 0, 1),
+            },
+          ],
+        },
+      ],
+    }
+    const data = toGanttData([group])
+    const leaf = data.tasks.find((t) => t.type === 'task')
+    expect(leaf?.end?.getFullYear()).toBe(2030)
+  })
+```
+
+- [ ] **Step 2: Write the failing grouper tests** — append to `assetGrouper.test.ts`:
+
+```ts
+  it('extends group/location span to barEnd', () => {
+    const assets: ParsedAsset[] = [
+      makeAsset({
+        assetId: 'EXP',
+        contractEnd: new Date(2024, 0, 1),
+        barEnd: new Date(2030, 0, 1),
+        daysRemaining: -100,
+      }),
+    ]
+    const groups = groupAssets(assets)
+    expect(groups[0]?.productGroups[0]?.groupEnd.getFullYear()).toBe(2030)
+    expect(groups[0]?.locationEnd.getFullYear()).toBe(2030)
+  })
+
+  it('sorts overdue (expired) locations ahead of active ones despite a later barEnd', () => {
+    const assets: ParsedAsset[] = [
+      makeAsset({
+        locationId: 'L_ACTIVE',
+        contractEnd: new Date(2028, 0, 1),
+        barEnd: new Date(2028, 0, 1),
+        daysRemaining: 700,
+      }),
+      makeAsset({
+        locationId: 'L_EXPIRED',
+        contractEnd: new Date(2024, 0, 1),
+        barEnd: new Date(2030, 0, 1),
+        daysRemaining: -100,
+      }),
+    ]
+    const groups = groupAssets(assets)
+    expect(groups[0]?.locationId).toBe('L_EXPIRED')
+  })
+```
+
+- [ ] **Step 3: Run both test files to verify they fail**
+
+Run: `npx vitest run src/engines/csv/__tests__/svarAdapter.test.ts src/engines/csv/__tests__/assetGrouper.test.ts`
+Expected: FAIL — adapter leaf `end` is still `contractEnd` (2024, not 2030); `groupEnd`/`locationEnd` still `contractEnd`-based (2024); the sort test may already pass but the span tests fail.
+
+- [ ] **Step 4: Draw `barEnd` in `svarAdapter.ts`**
+
+In the asset loop (lines 47-58), change the leaf task's `end` from `asset.contractEnd` to `asset.barEnd`:
+
+```ts
+      for (const asset of group.assets) {
+        const color = contractStatusColor(asset.daysRemaining)
+        tasks.push({
+          id: idCounter++,
+          text: `${asset.productName} (${asset.assetId})`,
+          start: asset.installDate,
+          end: asset.barEnd,
+          type: 'task',
+          parent: productId,
+          color,
+        })
+      }
+```
+
+- [ ] **Step 5: Rewrite `groupAssets`** in `src/engines/csv/assetGrouper.ts` — span uses `barEnd`, sort uses `contractEnd`. Replace the whole file body (keep the existing import line) with:
+
+```ts
+import type { LocationGroup, ParsedAsset, ProductGroup } from '@/types/asset'
+
+/** Latest of a list of dates (defaults to now for an empty list). */
+function latest(dates: Date[]): Date {
+  return dates.reduce((max, d) => (d > max ? d : max), dates[0] ?? new Date())
+}
+
+/** Earliest of a list of dates (defaults to now for an empty list). */
+function earliest(dates: Date[]): Date {
+  return dates.reduce((min, d) => (d < min ? d : min), dates[0] ?? new Date())
+}
+
+/**
+ * Groups parsed assets by locationId → productName.
+ * Summary spans (groupEnd / locationEnd) extend to the latest child barEnd,
+ * but ordering stays driven by contract end (soonest first) so the most
+ * urgent items — including overdue/expired contracts — appear at the top.
+ */
+export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
+  const locationMap = new Map<string, Map<string, ParsedAsset[]>>()
+
+  for (const asset of assets) {
+    let productMap = locationMap.get(asset.locationId)
+    if (!productMap) {
+      productMap = new Map()
+      locationMap.set(asset.locationId, productMap)
+    }
+    const existing = productMap.get(asset.productName) ?? []
+    existing.push(asset)
+    productMap.set(asset.productName, existing)
+  }
+
+  const locationGroups: LocationGroup[] = []
+
+  for (const [locationId, productMap] of locationMap) {
+    const productGroups: ProductGroup[] = []
+
+    for (const [productName, productAssets] of productMap) {
+      // Sort assets within a product group by contract end (soonest first)
+      productAssets.sort((a, b) => a.contractEnd.getTime() - b.contractEnd.getTime())
+
+      const groupStart = earliest(productAssets.map((a) => a.installDate))
+      // Span extends to the latest bar end (end-of-support for expired assets)
+      const groupEnd = latest(productAssets.map((a) => a.barEnd))
+
+      productGroups.push({ productName, assets: productAssets, groupStart, groupEnd })
+    }
+
+    // Order product groups by urgency: latest contract end (NOT barEnd), soonest first
+    productGroups.sort(
+      (a, b) =>
+        latest(a.assets.map((x) => x.contractEnd)).getTime() -
+        latest(b.assets.map((x) => x.contractEnd)).getTime(),
+    )
+
+    const representative = assets.find((a) => a.locationId === locationId)
+    const locationStart = earliest(productGroups.map((g) => g.groupStart))
+    const locationEnd = latest(productGroups.map((g) => g.groupEnd))
+
+    locationGroups.push({
+      locationId,
+      locationName: representative?.locationName ?? locationId,
+      city: representative?.city ?? '',
+      country: representative?.country ?? '',
+      productGroups,
+      locationStart,
+      locationEnd,
+    })
+  }
+
+  // Order locations by urgency: latest contract end (NOT barEnd), soonest first
+  locationGroups.sort(
+    (a, b) =>
+      latest(a.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime() -
+      latest(b.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime(),
+  )
+
+  return locationGroups
+}
+```
+
+- [ ] **Step 6: Update doc comments** in `src/types/asset.ts` — change the `groupEnd` comment (line 36-37) to `/** Latest bar end across all assets in this group (extends to end-of-support for expired) */` and the `locationEnd` comment (line 49-50) to `/** Latest bar end across all products in this location */`.
+
+- [ ] **Step 7: Run both test files to verify they pass**
+
+Run: `npx vitest run src/engines/csv/__tests__/svarAdapter.test.ts src/engines/csv/__tests__/assetGrouper.test.ts`
+Expected: PASS — including the unchanged grouper tests (`computes groupStart…`, `sorts locations by end date…`, `computes locationStart/End…`), which stay green because `makeAsset` now defaults `barEnd` to `contractEnd`.
+
+- [ ] **Step 8: Full CI gate**
+
+Run: `make ci`
+Expected: typecheck + lint + test-coverage (≥75%) + build all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/engines/csv/svarAdapter.ts src/engines/csv/assetGrouper.ts src/types/asset.ts \
+  src/engines/csv/__tests__/svarAdapter.test.ts src/engines/csv/__tests__/assetGrouper.test.ts
+git commit  # message: "feat: draw bars to end-of-support for expired assets" + required trailers
+```
+
+---
+
+## Verification (end-to-end)
+
+- [ ] **Automated:** `make ci` passes (typecheck, Biome lint, Vitest coverage ≥75%, build).
+- [ ] **Manual, with the real CSV** that surfaced the bug:
+  1. `make dev`, open `http://localhost:5173/360gantt/`.
+  2. Load `~/Library/CloudStorage/OneDrive-Home/assets (7).csv`.
+  3. Confirm the Lausanne `F.H.V.I.` location now shows **9** VxRail E660F rows (1 blue active → Feb 2028, 8 gray expired → Jun 2030) and the Prilly location shows **5** (1 active, 4 expired) — previously only 1 each.
+  4. Confirm gray (expired) bars extend to mid-2030 (end of standard support) and blue (active) bars end Feb 2028.
+  5. Confirm the 2 VxRail **Software** rows remain absent (hardware-only).
+  6. Confirm overdue/expired groups sort toward the top (soonest contract end first).
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Decision 1 (show all statuses) → Task 1. Decision 2 (bar end = next deadline) → Task 2 (compute) + Task 3 (draw). Decision 3 (date-keyed expired) → Task 2 `daysRemaining < 0`. Decision 4 (color unchanged) → no task, reused `contractStatusColor`. Decision 5 (global) → Task 1 removes the status gate for all products. Hardware-only retained → unchanged `HARDWARE_VALUES` check + verified by `pipeline.test.ts` software case. Edge cases (no EOSS; active; unparseable contract date with EOSS fallback) → Task 2 tests + fallback logic.
+- **Placeholders:** none — every code step shows full content.
+- **Type consistency:** `endOfSupport: Date | null` and `barEnd: Date` are defined in Task 2 and consumed with the same names/types in Task 3; `latest`/`earliest` helpers defined and used within `assetGrouper.ts`.

--- a/docs/superpowers/plans/2026-06-24-expired-asset-visibility.md
+++ b/docs/superpowers/plans/2026-06-24-expired-asset-visibility.md
@@ -20,7 +20,7 @@
 - **Tests use Vitest globals:** do NOT import `describe`/`it`/`expect`.
 - **Engine layer is pure functions, no React imports.**
 - **Every commit message must end with these two trailers** (verbatim):
-  ```
+  ```text
   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
   Claude-Session: https://claude.ai/code/session_01PwjvYFwpYKQ3NvfnZtHtn2
   ```

--- a/docs/superpowers/specs/2026-06-24-expired-asset-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-24-expired-asset-visibility-design.md
@@ -1,0 +1,155 @@
+# Show all hardware assets; extend expired bars to end-of-support
+
+**Date:** 2026-06-24
+**Status:** Approved (design)
+**Area:** CSV engine layer (`src/engines/csv/`), `src/utils/colors.ts`, `src/types/asset.ts`
+
+## Problem
+
+A user's CSV (`assets (7).csv`) contains 14 VxRail **hardware** rows, but only **2**
+appear in the Gantt. The Lausanne location (`F.H.V.I.`, loc `10897094552`) holds 9
+VxRail nodes; the user expects to see ~8 of them and sees only 1.
+
+### Root cause
+
+`isIncluded()` in `src/engines/csv/assetFilter.ts` (lines 39–40) drops any row whose
+`SERVICES STATUS` is not in `ACTIVE_VALUES`. Of the 14 VxRail hardware rows, **12 are
+`Ended`** (contracts that lapsed `February 01, 2026`) and only **2 are `Active`**
+(`DE600230783159` Lausanne, `DE600230783158` Prilly — both ending `February 28, 2028`).
+The two `Active` rows are exactly what renders. A further 2 VxRail rows are
+`SOFTWARE` and excluded by the (retained) hardware-only filter.
+
+This is not a parsing defect — the filter does what it was written to do. The
+requirement was too narrow: lapsed-contract hardware is the highest-risk category
+(already out of contract) and was being hidden.
+
+### Data summary (from the source CSV)
+
+| VxRail rows | PRODUCT TYPE | SERVICES STATUS | Reaches Gantt today |
+| ----------- | ------------ | --------------- | ------------------- |
+| 2           | HARDWARE     | Active          | yes                 |
+| 12          | HARDWARE     | Ended           | no (filtered)       |
+| 2           | SOFTWARE     | Active          | no (not hardware)   |
+
+All 14 hardware rows share `END OF STANDARD SUPPORT = June 30, 2030`.
+
+## Goal
+
+Show **all hardware assets** regardless of service-contract status, and represent each
+asset's bar so it ends on its **next actionable deadline**:
+
+- **Live contract** → bar ends at contract end (the renew-by date).
+- **Lapsed contract** → bar ends at end of standard support (the replace-by date).
+
+Lapsed assets remain visually distinct (gray) so the chart communicates contract
+status by color and replacement horizon by bar length.
+
+## Decisions
+
+1. **Show all statuses.** Drop the `SERVICES STATUS = Active` gate. Keep the
+   `PRODUCT TYPE = HARDWARE` gate (hardware-only). Software assets remain excluded.
+2. **Bar end = next actionable deadline.**
+   - `daysRemaining >= 0` → `barEnd = contractEnd` (unchanged from today's behavior).
+   - `daysRemaining < 0` → `barEnd = endOfSupport ?? contractEnd`.
+3. **"Expired" is keyed off the date** (`daysRemaining < 0`), not the `Ended` status
+   string. This matches the existing color threshold in `colors.ts` and is robust
+   across the EN/FR/IT/DE status values. The `SERVICES STATUS` string is no longer
+   used in filtering or display logic.
+4. **Color is unchanged.** `contractStatusColor(daysRemaining)` already returns gray
+   (`#9ca3af`) for `daysRemaining < 0`. Color carries contract status; bar length
+   carries the replacement horizon.
+5. **Filter change is global**, not VxRail-specific. The filter is product-agnostic;
+   every uploaded CSV will now show lapsed hardware. The bug merely surfaced via VxRail.
+
+## Changes
+
+### 1. `src/engines/csv/assetFilter.ts` — `isIncluded()`
+
+Remove the `ACTIVE_VALUES` status check. New rule:
+
+- `PRODUCT TYPE` matches `HARDWARE_VALUES` (any language), **and**
+- a parseable date exists: `parseContractDate(contractEndDate) ?? parseContractDate(endOfStandardSupport)`.
+
+Result: all 14 VxRail hardware rows pass.
+
+### 2. `src/types/asset.ts` — `ParsedAsset`
+
+Add two fields:
+
+```ts
+/** Parsed END OF STANDARD SUPPORT date, or null if absent/unparseable */
+endOfSupport: Date | null
+/** Bar end date: contractEnd if live, else endOfSupport ?? contractEnd */
+barEnd: Date
+```
+
+### 3. `src/engines/csv/assetFilter.ts` — `toParsedAsset()`
+
+- Parse `END OF STANDARD SUPPORT` into `endOfSupport: Date | null`.
+- Compute `barEnd`:
+  ```ts
+  const barEnd = daysRemaining < 0 ? (endOfSupport ?? contractEnd) : contractEnd
+  ```
+- `contractEnd` and `daysRemaining` keep their current meaning (sorting + color).
+
+### 4. `src/engines/csv/svarAdapter.ts`
+
+In the asset-task push (line ~54), draw `end: asset.barEnd` instead of
+`asset.contractEnd`. Color stays `contractStatusColor(asset.daysRemaining)`.
+
+### 5. `src/engines/csv/assetGrouper.ts` — separate span from sort order
+
+- **Span:** compute `groupEnd` / `locationEnd` as the max of child `barEnd` (not
+  `contractEnd`) so parent summary bars cover their extended children.
+- **Sort order preserved:** continue sorting product groups and locations by their max
+  `contractEnd` (the urgency date), *not* `barEnd`. This keeps the existing
+  "most-urgent-first" ordering unchanged for live contracts, and lets all-expired
+  groups (past `contractEnd`) rise to the top naturally. Within-group asset sort stays
+  by `contractEnd` ascending.
+- Update the doc comments on `groupEnd` / `locationEnd` in `src/types/asset.ts` to say
+  "latest bar end" rather than "latest contract end."
+
+### 6. `src/utils/colors.ts`
+
+No change. The `daysRemaining < 0 → gray` branch already exists and is reused as-is.
+
+## Visual result
+
+- **Lausanne (`F.H.V.I.`, loc 10897094552):** 9 VxRail nodes — 1 blue (active, → Feb 28
+  2028) and 8 gray (expired, → June 30 2030).
+- **Prilly (loc 69761739194366):** 5 VxRail nodes — 1 active, 4 expired.
+- VxRail Software rows stay excluded.
+
+## Edge cases
+
+- **Expired, no EOSS date:** `barEnd = contractEnd` (bar sits entirely in the past) —
+  truthful "fully end-of-life."
+- **Active contract:** behavior unchanged (`barEnd = contractEnd`).
+- **Contract date unparseable but EOSS parseable:** row is still included via the
+  fallback; `contractEnd`/`daysRemaining` derive from EOSS as today, and
+  `barEnd = contractEnd` (= the EOSS fallback). Consistent.
+- **`Ended` status with a future contract date (unusual):** treated as live
+  (`daysRemaining >= 0`) — bar ends at contract end, not extended. Accepted: the
+  date-based rule is preferred over the status string. Noted as a deliberate trade-off.
+
+## Testing
+
+Engine layer is pure functions with a ≥75% coverage threshold (CI-enforced).
+
+- **Update** existing `assetFilter` tests that assert `Ended`/non-Active rows are
+  excluded — they are now included when hardware + parseable date.
+- **Add** cases:
+  - Lapsed hardware row (`Ended`, past `contractEnd`, parseable) is **included**.
+  - `barEnd` equals `endOfSupport` for an expired asset; equals `contractEnd` for a
+    live asset; falls back to `contractEnd` when `endOfSupport` is absent.
+  - Expired asset resolves to the gray color via `contractStatusColor`.
+  - `assetGrouper` summary `groupEnd` / `locationEnd` span covers an extended child
+    `barEnd`, while sort order remains driven by `contractEnd`.
+- Hardware-only filter still excludes `SOFTWARE` rows.
+
+## Out of scope (possible follow-ups)
+
+- Color legend update explaining the gray "expired" state.
+- An explicit end-of-support milestone marker on each row (show both dates).
+- Including software assets.
+- Surfacing `SERVICES STATUS` in a tooltip.

--- a/src/engines/csv/__tests__/assetFilter.test.ts
+++ b/src/engines/csv/__tests__/assetFilter.test.ts
@@ -178,4 +178,18 @@ describe('barEnd / endOfSupport', () => {
     expect(parsed.endOfSupport).toBeNull()
     expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
   })
+
+  it('treats an ended-status asset with a future contract date as live (barEnd = contractEnd)', () => {
+    const parsed = toParsedAsset(
+      {
+        ...baseAsset,
+        servicesStatus: 'Ended',
+        contractEndDate: 'December 31, 2027',
+        endOfStandardSupport: 'June 30, 2030',
+      },
+      today,
+    )
+    expect(parsed.daysRemaining).toBeGreaterThan(0)
+    expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
+  })
 })

--- a/src/engines/csv/__tests__/assetFilter.test.ts
+++ b/src/engines/csv/__tests__/assetFilter.test.ts
@@ -25,8 +25,8 @@ describe('isIncluded', () => {
     expect(isIncluded({ ...baseAsset, productType: 'SOFTWARE' })).toBe(false)
   })
 
-  it('excludes non-active status', () => {
-    expect(isIncluded({ ...baseAsset, servicesStatus: 'Ended' })).toBe(false)
+  it('includes non-active (ended) hardware', () => {
+    expect(isIncluded({ ...baseAsset, servicesStatus: 'Ended' })).toBe(true)
   })
 
   it('excludes missing contract end date', () => {
@@ -133,15 +133,15 @@ describe('toRawAsset', () => {
 })
 
 describe('filterAssets', () => {
-  it('returns only parseable hardware/active assets', () => {
+  it('returns all parseable hardware assets regardless of status', () => {
     const raws: RawAsset[] = [
       { ...baseAsset, assetId: 'KEEP' },
       { ...baseAsset, assetId: 'SKIP_SW', productType: 'SOFTWARE' },
-      { ...baseAsset, assetId: 'SKIP_END', servicesStatus: 'Ended' },
+      { ...baseAsset, assetId: 'ENDED', servicesStatus: 'Ended' },
     ]
     const parsed = filterAssets(raws)
-    expect(parsed).toHaveLength(1)
-    expect(parsed[0]?.assetId).toBe('KEEP')
+    expect(parsed).toHaveLength(2)
+    expect(parsed.map((p) => p.assetId).sort()).toEqual(['ENDED', 'KEEP'])
   })
 
   it('returns empty array when nothing matches', () => {

--- a/src/engines/csv/__tests__/assetFilter.test.ts
+++ b/src/engines/csv/__tests__/assetFilter.test.ts
@@ -148,3 +148,34 @@ describe('filterAssets', () => {
     expect(filterAssets([{ ...baseAsset, productType: 'SOFTWARE' }])).toHaveLength(0)
   })
 })
+
+describe('barEnd / endOfSupport', () => {
+  const today = new Date(2025, 0, 1)
+
+  it('uses contractEnd as barEnd for a live contract', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'December 31, 2027', endOfStandardSupport: 'June 30, 2030' },
+      today,
+    )
+    expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
+    expect(parsed.endOfSupport?.getFullYear()).toBe(2030)
+  })
+
+  it('extends barEnd to endOfSupport for an expired contract', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'February 01, 2020', endOfStandardSupport: 'June 30, 2030' },
+      today,
+    )
+    expect(parsed.daysRemaining).toBeLessThan(0)
+    expect(parsed.barEnd.getFullYear()).toBe(2030)
+  })
+
+  it('falls back to contractEnd as barEnd when an expired contract has no endOfSupport', () => {
+    const parsed = toParsedAsset(
+      { ...baseAsset, contractEndDate: 'February 01, 2020', endOfStandardSupport: '' },
+      today,
+    )
+    expect(parsed.endOfSupport).toBeNull()
+    expect(parsed.barEnd.getTime()).toBe(parsed.contractEnd.getTime())
+  })
+})

--- a/src/engines/csv/__tests__/assetGrouper.test.ts
+++ b/src/engines/csv/__tests__/assetGrouper.test.ts
@@ -106,10 +106,10 @@ describe('groupAssets', () => {
     expect(groups[0]?.locationId).toBe('L_EXPIRED')
   })
 
-  it('orders a mixed location group by its max contractEnd, not barEnd', () => {
+  it('surfaces a mixed location with overdue work above a fully-live location', () => {
     const assets: ParsedAsset[] = [
-      // Mixed group (same location + product): an overdue asset whose bar extends to 2030,
-      // plus a live sibling that caps the group's max contractEnd at 2027.
+      // Mixed group (same location + product): an overdue asset (2023, bar extends to
+      // 2030) plus a far-future live sibling (2029).
       makeAsset({
         assetId: 'EXP',
         locationId: 'L_MIX',
@@ -118,24 +118,24 @@ describe('groupAssets', () => {
         daysRemaining: -800,
       }),
       makeAsset({
-        assetId: 'LIVE',
+        assetId: 'FUTURE',
         locationId: 'L_MIX',
-        contractEnd: new Date(2027, 0, 1),
-        barEnd: new Date(2027, 0, 1),
-        daysRemaining: 600,
+        contractEnd: new Date(2029, 0, 1),
+        barEnd: new Date(2029, 0, 1),
+        daysRemaining: 1500,
       }),
-      // A separate, later single-asset location.
+      // A fully-live location whose contract ends 2026.
       makeAsset({
-        locationId: 'L_LATE',
-        contractEnd: new Date(2028, 0, 1),
-        barEnd: new Date(2028, 0, 1),
-        daysRemaining: 900,
+        locationId: 'L_LIVE',
+        contractEnd: new Date(2026, 0, 1),
+        barEnd: new Date(2026, 0, 1),
+        daysRemaining: 365,
       }),
     ]
     const groups = groupAssets(assets)
-    // L_MIX's sort key is its max contractEnd (2027), NOT its max barEnd (2030),
-    // so it precedes L_LATE (2028). If the aggregate sort keyed on barEnd, L_MIX
-    // (2030) would sort last — this pins that it keys on contractEnd.
-    expect(groups.map((g) => g.locationId)).toEqual(['L_MIX', 'L_LATE'])
+    // L_MIX's urgency is its SOONEST contract end (2023, overdue), so it sorts above
+    // L_LIVE (2026) despite also holding a 2029 contract. If ordering keyed on the
+    // latest contract end (2029) — or on barEnd (2030) — L_MIX would sort BELOW L_LIVE.
+    expect(groups.map((g) => g.locationId)).toEqual(['L_MIX', 'L_LIVE'])
   })
 })

--- a/src/engines/csv/__tests__/assetGrouper.test.ts
+++ b/src/engines/csv/__tests__/assetGrouper.test.ts
@@ -105,4 +105,37 @@ describe('groupAssets', () => {
     const groups = groupAssets(assets)
     expect(groups[0]?.locationId).toBe('L_EXPIRED')
   })
+
+  it('orders a mixed location group by its max contractEnd, not barEnd', () => {
+    const assets: ParsedAsset[] = [
+      // Mixed group (same location + product): an overdue asset whose bar extends to 2030,
+      // plus a live sibling that caps the group's max contractEnd at 2027.
+      makeAsset({
+        assetId: 'EXP',
+        locationId: 'L_MIX',
+        contractEnd: new Date(2023, 0, 1),
+        barEnd: new Date(2030, 0, 1),
+        daysRemaining: -800,
+      }),
+      makeAsset({
+        assetId: 'LIVE',
+        locationId: 'L_MIX',
+        contractEnd: new Date(2027, 0, 1),
+        barEnd: new Date(2027, 0, 1),
+        daysRemaining: 600,
+      }),
+      // A separate, later single-asset location.
+      makeAsset({
+        locationId: 'L_LATE',
+        contractEnd: new Date(2028, 0, 1),
+        barEnd: new Date(2028, 0, 1),
+        daysRemaining: 900,
+      }),
+    ]
+    const groups = groupAssets(assets)
+    // L_MIX's sort key is its max contractEnd (2027), NOT its max barEnd (2030),
+    // so it precedes L_LATE (2028). If the aggregate sort keyed on barEnd, L_MIX
+    // (2030) would sort last — this pins that it keys on contractEnd.
+    expect(groups.map((g) => g.locationId)).toEqual(['L_MIX', 'L_LATE'])
+  })
 })

--- a/src/engines/csv/__tests__/assetGrouper.test.ts
+++ b/src/engines/csv/__tests__/assetGrouper.test.ts
@@ -72,4 +72,37 @@ describe('groupAssets', () => {
     expect(loc?.locationStart.getFullYear()).toBe(2019)
     expect(loc?.locationEnd.getFullYear()).toBe(2030)
   })
+
+  it('extends group/location span to barEnd', () => {
+    const assets: ParsedAsset[] = [
+      makeAsset({
+        assetId: 'EXP',
+        contractEnd: new Date(2024, 0, 1),
+        barEnd: new Date(2030, 0, 1),
+        daysRemaining: -100,
+      }),
+    ]
+    const groups = groupAssets(assets)
+    expect(groups[0]?.productGroups[0]?.groupEnd.getFullYear()).toBe(2030)
+    expect(groups[0]?.locationEnd.getFullYear()).toBe(2030)
+  })
+
+  it('sorts overdue (expired) locations ahead of active ones despite a later barEnd', () => {
+    const assets: ParsedAsset[] = [
+      makeAsset({
+        locationId: 'L_ACTIVE',
+        contractEnd: new Date(2028, 0, 1),
+        barEnd: new Date(2028, 0, 1),
+        daysRemaining: 700,
+      }),
+      makeAsset({
+        locationId: 'L_EXPIRED',
+        contractEnd: new Date(2024, 0, 1),
+        barEnd: new Date(2030, 0, 1),
+        daysRemaining: -100,
+      }),
+    ]
+    const groups = groupAssets(assets)
+    expect(groups[0]?.locationId).toBe('L_EXPIRED')
+  })
 })

--- a/src/engines/csv/__tests__/assetGrouper.test.ts
+++ b/src/engines/csv/__tests__/assetGrouper.test.ts
@@ -2,6 +2,7 @@ import { groupAssets } from '../assetGrouper'
 import type { ParsedAsset } from '@/types/asset'
 
 function makeAsset(overrides: Partial<ParsedAsset> = {}): ParsedAsset {
+  const contractEnd = overrides.contractEnd ?? new Date(2027, 0, 1)
   return {
     assetId: 'A1',
     productName: 'PowerEdge R740',
@@ -10,9 +11,11 @@ function makeAsset(overrides: Partial<ParsedAsset> = {}): ParsedAsset {
     city: 'Geneva',
     country: 'Switzerland',
     installDate: new Date(2022, 0, 1),
-    contractEnd: new Date(2027, 0, 1),
     daysRemaining: 730,
+    endOfSupport: null,
     ...overrides,
+    contractEnd,
+    barEnd: overrides.barEnd ?? contractEnd,
   }
 }
 

--- a/src/engines/csv/__tests__/svarAdapter.test.ts
+++ b/src/engines/csv/__tests__/svarAdapter.test.ts
@@ -25,6 +25,8 @@ function makeLocationGroup(): LocationGroup {
             installDate: new Date(2022, 0, 1),
             contractEnd: new Date(2027, 0, 1),
             daysRemaining: 730,
+            endOfSupport: null,
+            barEnd: new Date(2027, 0, 1),
           },
         ],
       },

--- a/src/engines/csv/__tests__/svarAdapter.test.ts
+++ b/src/engines/csv/__tests__/svarAdapter.test.ts
@@ -73,4 +73,40 @@ describe('toGanttData', () => {
     expect(data.tasks).toHaveLength(0)
     expect(data.links).toHaveLength(0)
   })
+
+  it('uses barEnd (not contractEnd) for the asset bar end', () => {
+    const group: LocationGroup = {
+      locationId: 'L1',
+      locationName: 'Main DC',
+      city: 'Geneva',
+      country: 'Switzerland',
+      locationStart: new Date(2022, 0, 1),
+      locationEnd: new Date(2030, 0, 1),
+      productGroups: [
+        {
+          productName: 'VxRail E660F',
+          groupStart: new Date(2022, 0, 1),
+          groupEnd: new Date(2030, 0, 1),
+          assets: [
+            {
+              assetId: 'EXP',
+              productName: 'VxRail E660F',
+              locationId: 'L1',
+              locationName: 'Main DC',
+              city: 'Geneva',
+              country: 'Switzerland',
+              installDate: new Date(2022, 0, 1),
+              contractEnd: new Date(2024, 0, 1),
+              daysRemaining: -100,
+              endOfSupport: new Date(2030, 0, 1),
+              barEnd: new Date(2030, 0, 1),
+            },
+          ],
+        },
+      ],
+    }
+    const data = toGanttData([group])
+    const leaf = data.tasks.find((t) => t.type === 'task')
+    expect(leaf?.end?.getFullYear()).toBe(2030)
+  })
 })

--- a/src/engines/csv/assetFilter.ts
+++ b/src/engines/csv/assetFilter.ts
@@ -45,9 +45,10 @@ export function isIncluded(raw: RawAsset): boolean {
  * Assumes isIncluded() has already returned true.
  */
 export function toParsedAsset(raw: RawAsset, today = new Date()): ParsedAsset {
+  const endOfSupport = parseContractDate(raw.endOfStandardSupport)
   const contractEnd =
     // biome-ignore lint/style/noNonNullAssertion: guaranteed by isIncluded()
-    parseContractDate(raw.contractEndDate) ?? parseContractDate(raw.endOfStandardSupport)!
+    parseContractDate(raw.contractEndDate) ?? endOfSupport!
 
   const installDate = parseInstallBaseAge(raw.installBaseAge, today) ?? contractEnd
 
@@ -55,7 +56,6 @@ export function toParsedAsset(raw: RawAsset, today = new Date()): ParsedAsset {
     (contractEnd.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
   )
 
-  const endOfSupport = parseContractDate(raw.endOfStandardSupport)
   const barEnd = daysRemaining < 0 ? (endOfSupport ?? contractEnd) : contractEnd
 
   return {

--- a/src/engines/csv/assetFilter.ts
+++ b/src/engines/csv/assetFilter.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_VALUES, HARDWARE_VALUES, type FieldMap } from './headerResolver'
+import { HARDWARE_VALUES, type FieldMap } from './headerResolver'
 import { parseContractDate, parseInstallBaseAge } from './dateParser'
 import type { ParsedAsset, RawAsset } from '@/types/asset'
 
@@ -29,15 +29,11 @@ export function toRawAsset(row: Record<string, string>, fieldMap: FieldMap): Raw
 /**
  * Returns true if the raw asset should be included in the Gantt chart:
  *  - product type is HARDWARE (any language)
- *  - services status is Active (any language)
  *  - has a parseable contract end date (or end of standard support)
  */
 export function isIncluded(raw: RawAsset): boolean {
   const typeUpper = raw.productType.toUpperCase()
   if (!HARDWARE_VALUES.some((v) => v.toUpperCase() === typeUpper)) return false
-
-  const statusLower = raw.servicesStatus.toLowerCase()
-  if (!ACTIVE_VALUES.some((v) => v.toLowerCase() === statusLower)) return false
 
   const contractEnd =
     parseContractDate(raw.contractEndDate) ?? parseContractDate(raw.endOfStandardSupport)

--- a/src/engines/csv/assetFilter.ts
+++ b/src/engines/csv/assetFilter.ts
@@ -55,6 +55,9 @@ export function toParsedAsset(raw: RawAsset, today = new Date()): ParsedAsset {
     (contractEnd.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
   )
 
+  const endOfSupport = parseContractDate(raw.endOfStandardSupport)
+  const barEnd = daysRemaining < 0 ? (endOfSupport ?? contractEnd) : contractEnd
+
   return {
     assetId: raw.assetId,
     productName: raw.productName,
@@ -65,6 +68,8 @@ export function toParsedAsset(raw: RawAsset, today = new Date()): ParsedAsset {
     installDate,
     contractEnd,
     daysRemaining,
+    endOfSupport,
+    barEnd,
   }
 }
 

--- a/src/engines/csv/assetGrouper.ts
+++ b/src/engines/csv/assetGrouper.ts
@@ -54,11 +54,12 @@ export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
       productGroups.push({ productName, assets: productAssets, groupStart, groupEnd })
     }
 
-    // Order product groups by urgency: latest contract end (NOT barEnd), soonest first
+    // Order product groups by urgency: soonest (earliest) contract end first, so a
+    // group with any overdue asset surfaces even if it also holds far-future ones.
     productGroups.sort(
       (a, b) =>
-        latest(a.assets.map((x) => x.contractEnd)).getTime() -
-        latest(b.assets.map((x) => x.contractEnd)).getTime(),
+        earliest(a.assets.map((x) => x.contractEnd)).getTime() -
+        earliest(b.assets.map((x) => x.contractEnd)).getTime(),
     )
 
     const representative = assets.find((a) => a.locationId === locationId)
@@ -76,11 +77,13 @@ export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
     })
   }
 
-  // Order locations by urgency: latest contract end (NOT barEnd), soonest first
+  // Order locations by urgency: soonest (earliest) contract end first — a location
+  // with any overdue asset surfaces above fully-live ones, even when it also holds
+  // far-future contracts. Keyed on contractEnd, NOT barEnd.
   locationGroups.sort(
     (a, b) =>
-      latest(a.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime() -
-      latest(b.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime(),
+      earliest(a.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime() -
+      earliest(b.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime(),
   )
 
   return locationGroups

--- a/src/engines/csv/assetGrouper.ts
+++ b/src/engines/csv/assetGrouper.ts
@@ -1,13 +1,21 @@
 import type { LocationGroup, ParsedAsset, ProductGroup } from '@/types/asset'
 
-/** Latest of a list of dates (defaults to now for an empty list). */
+/** Latest of a non-empty list of dates. Throws if the list is empty. */
 function latest(dates: Date[]): Date {
-  return dates.reduce((max, d) => (d > max ? d : max), dates[0] ?? new Date())
+  const first = dates[0]
+  if (first === undefined) throw new Error('latest(): empty date list')
+  let max = first
+  for (const d of dates) if (d > max) max = d
+  return max
 }
 
-/** Earliest of a list of dates (defaults to now for an empty list). */
+/** Earliest of a non-empty list of dates. Throws if the list is empty. */
 function earliest(dates: Date[]): Date {
-  return dates.reduce((min, d) => (d < min ? d : min), dates[0] ?? new Date())
+  const first = dates[0]
+  if (first === undefined) throw new Error('earliest(): empty date list')
+  let min = first
+  for (const d of dates) if (d < min) min = d
+  return min
 }
 
 /**

--- a/src/engines/csv/assetGrouper.ts
+++ b/src/engines/csv/assetGrouper.ts
@@ -1,12 +1,22 @@
 import type { LocationGroup, ParsedAsset, ProductGroup } from '@/types/asset'
 
+/** Latest of a list of dates (defaults to now for an empty list). */
+function latest(dates: Date[]): Date {
+  return dates.reduce((max, d) => (d > max ? d : max), dates[0] ?? new Date())
+}
+
+/** Earliest of a list of dates (defaults to now for an empty list). */
+function earliest(dates: Date[]): Date {
+  return dates.reduce((min, d) => (d < min ? d : min), dates[0] ?? new Date())
+}
+
 /**
  * Groups parsed assets by locationId → productName.
- * Locations and product groups are sorted by their end date (soonest first)
- * so the most urgent items appear at the top.
+ * Summary spans (groupEnd / locationEnd) extend to the latest child barEnd,
+ * but ordering stays driven by contract end (soonest first) so the most
+ * urgent items — including overdue/expired contracts — appear at the top.
  */
 export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
-  // Accumulate into a map: locationId → productName → assets[]
   const locationMap = new Map<string, Map<string, ParsedAsset[]>>()
 
   for (const asset of assets) {
@@ -29,30 +39,23 @@ export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
       // Sort assets within a product group by contract end (soonest first)
       productAssets.sort((a, b) => a.contractEnd.getTime() - b.contractEnd.getTime())
 
-      const groupStart = productAssets.reduce(
-        (min, a) => (a.installDate < min ? a.installDate : min),
-        productAssets[0]?.installDate ?? new Date(),
-      )
-      const groupEnd = productAssets.reduce(
-        (max, a) => (a.contractEnd > max ? a.contractEnd : max),
-        productAssets[0]?.contractEnd ?? new Date(),
-      )
+      const groupStart = earliest(productAssets.map((a) => a.installDate))
+      // Span extends to the latest bar end (end-of-support for expired assets)
+      const groupEnd = latest(productAssets.map((a) => a.barEnd))
 
       productGroups.push({ productName, assets: productAssets, groupStart, groupEnd })
     }
 
-    // Sort product groups by their end date
-    productGroups.sort((a, b) => a.groupEnd.getTime() - b.groupEnd.getTime())
+    // Order product groups by urgency: latest contract end (NOT barEnd), soonest first
+    productGroups.sort(
+      (a, b) =>
+        latest(a.assets.map((x) => x.contractEnd)).getTime() -
+        latest(b.assets.map((x) => x.contractEnd)).getTime(),
+    )
 
     const representative = assets.find((a) => a.locationId === locationId)
-    const locationStart = productGroups.reduce(
-      (min, g) => (g.groupStart < min ? g.groupStart : min),
-      productGroups[0]?.groupStart ?? new Date(),
-    )
-    const locationEnd = productGroups.reduce(
-      (max, g) => (g.groupEnd > max ? g.groupEnd : max),
-      productGroups[0]?.groupEnd ?? new Date(),
-    )
+    const locationStart = earliest(productGroups.map((g) => g.groupStart))
+    const locationEnd = latest(productGroups.map((g) => g.groupEnd))
 
     locationGroups.push({
       locationId,
@@ -65,8 +68,12 @@ export function groupAssets(assets: ParsedAsset[]): LocationGroup[] {
     })
   }
 
-  // Sort locations by end date
-  locationGroups.sort((a, b) => a.locationEnd.getTime() - b.locationEnd.getTime())
+  // Order locations by urgency: latest contract end (NOT barEnd), soonest first
+  locationGroups.sort(
+    (a, b) =>
+      latest(a.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime() -
+      latest(b.productGroups.flatMap((g) => g.assets.map((x) => x.contractEnd))).getTime(),
+  )
 
   return locationGroups
 }

--- a/src/engines/csv/svarAdapter.ts
+++ b/src/engines/csv/svarAdapter.ts
@@ -50,7 +50,7 @@ export function toGanttData(locationGroups: LocationGroup[]): GanttData {
           id: idCounter++,
           text: `${asset.productName} (${asset.assetId})`,
           start: asset.installDate,
-          end: asset.contractEnd,
+          end: asset.barEnd,
           type: 'task',
           parent: productId,
           color,

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -37,7 +37,7 @@ export interface ProductGroup {
   assets: ParsedAsset[]
   /** Earliest install date across all assets in this group */
   groupStart: Date
-  /** Latest contract end date across all assets in this group */
+  /** Latest bar end across all assets in this group (extends to end-of-support for expired) */
   groupEnd: Date
 }
 
@@ -50,7 +50,7 @@ export interface LocationGroup {
   productGroups: ProductGroup[]
   /** Earliest install date across all products in this location */
   locationStart: Date
-  /** Latest contract end date across all products in this location */
+  /** Latest bar end across all products in this location */
   locationEnd: Date
 }
 

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -25,6 +25,10 @@ export interface ParsedAsset {
   contractEnd: Date
   /** Days until contract end (negative = already expired) */
   daysRemaining: number
+  /** Parsed END OF STANDARD SUPPORT date, or null if absent/unparseable */
+  endOfSupport: Date | null
+  /** Bar end date: contractEnd while the contract is live, else endOfSupport ?? contractEnd */
+  barEnd: Date
 }
 
 // Assets sharing the same product name within a location


### PR DESCRIPTION
## Problem

A user's CSV (`assets (7).csv`) had 14 VxRail **hardware** rows but only **2** showed in the Gantt. Root cause: `isIncluded()` (`assetFilter.ts`) dropped any row whose `SERVICES STATUS` wasn't `Active` — and 12 of the 14 were `Ended` (contracts that lapsed Feb 1 2026). Lapsed-contract hardware is the highest-risk category (already out of contract) and was being hidden entirely.

## What changed

- **Show all hardware regardless of contract status.** Removed the `Active`-only gate; kept the hardware-only gate and the parseable-date requirement. Software is still excluded.
- **Bar end = next actionable deadline.** New `ParsedAsset.barEnd` = `contractEnd` while a contract is live (renew-by), or **end of standard support** once lapsed (`daysRemaining < 0 ? endOfSupport ?? contractEnd : contractEnd`) — the replace-by horizon. Added `endOfSupport: Date | null`.
- **Adapter draws `barEnd`; grouper spans extend to cover it**, while location/product **ordering stays driven by `contractEnd`** so overdue/expired groups stay at the top instead of being buried by their later end-of-support span.
- **Color unchanged** — expired assets render gray via the pre-existing `contractStatusColor(daysRemaining < 0)` branch. Color = contract status, bar length = replacement horizon.

## Result

For the reported file: the Lausanne `F.H.V.I.` location now shows its 9 VxRail nodes (1 blue active → Feb 2028, 8 gray expired → Jun 2030) and Prilly shows its 5 — previously only 1 each. Live contracts are behavior-preserving (`barEnd === contractEnd`).

## Testing

- TDD throughout; `make ci` green — **98 tests**, coverage 97.12% stmts / 88.99% branches / 97.72% funcs / 100% lines (threshold ≥75%), build OK.
- New tests cover the three `barEnd` branches (live / expired-with-EOSS / expired-without-EOSS), the grouper span-vs-sort invariant (expired sorts ahead despite later span), and the deliberate "Ended status + future contract date → treated as live" edge case.

## Docs

- Spec: `docs/superpowers/specs/2026-06-24-expired-asset-visibility-design.md`
- Plan: `docs/superpowers/plans/2026-06-24-expired-asset-visibility.md`

## Deferred follow-ups (pre-existing, out of scope)

- `daysRemaining` is timezone-naive — a DST-boundary contract ending "today" could read as `-1`. Now load-bearing for the `barEnd` threshold; worth normalizing to midnight-UTC separately.
- `assetGrouper` `representative` lookup is O(N) per location (negligible at CSV scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware assets are now shown regardless of service status.
  * Expired assets can display an extended end date based on standard support coverage, and Gantt bars use this updated end logic.

* **Bug Fixes**
  * Improved consistency between what’s included, how “next actionable” end dates are derived, and how grouped spans render.

* **Documentation**
  * Updated README and pipeline documentation to reflect the new hardware inclusion and end-date rules.

* **Tests**
  * Expanded/adjusted unit tests for asset filtering, grouping span ends, and Gantt task end dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->