### PR TITLE
feat: filter the Gantt by contract status via an interactive legend

### DIFF
--- a/docs/superpowers/plans/2026-06-24-legend-status-filter.md
+++ b/docs/superpowers/plans/2026-06-24-legend-status-filter.md
@@ -1,0 +1,438 @@
+# Legend Status Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing `FilterPanel` legend interactive so users can toggle the four contract-status buckets (OK / Warning / Critical / Expired) to show/hide those assets in the Gantt.
+
+**Architecture:** A pure engine helper (`filterGroupsByStatus`) does the filtering by re-grouping the kept assets; the store gains a `statuses` visible-set (default all four); `GanttPanel` inserts the helper into its existing filter pipeline; `FilterPanel` turns the static legend rows into toggle buttons. A shared `STATUS_ORDER` constant removes magic numbers and DRYs the status list.
+
+**Tech Stack:** TypeScript (strict), Zustand store, React + react-i18next, Vitest (jsdom, globals), Biome.
+
+**Context / why:** v1.2.0 made lapsed contracts visible; users now want to focus the view ("only active", "only expired"). `FilterPanel.tsx` already renders a static 4-bucket legend — this wires it up as a filter. Spec: `docs/superpowers/specs/2026-06-24-legend-status-filter-design.md`.
+
+**Branch:** `feat/legend-status-filter` (already checked out; spec committed there).
+
+## Global Constraints
+
+- **Coverage threshold ≥ 75%** (lines/functions/branches/statements) applies ONLY to `src/engines/**` and `src/utils/**` (per `vitest.config.ts` `coverage.include`). The new `statusFilter.ts` (engine) and `STATUS_ORDER` (utils) must stay covered; the store and components are out of the coverage scope.
+- **Vitest globals** — do NOT import `describe`/`it`/`expect` (config has `globals: true`; `vitest/globals` is in tsconfig types).
+- **Biome** is the sole linter/formatter. **TypeScript strict** — no new `as any`.
+- **No magic number for the bucket count** — use `STATUS_ORDER.length`, never a literal `4`.
+- **i18n:** every user-facing string goes through `t(...)`; add new keys to ALL FOUR locales (`en`, `fr`, `it`, `de`).
+- **Every commit message must end with these two trailers** (verbatim):
+  ```text
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01PwjvYFwpYKQ3NvfnZtHtn2
+  ```
+- Single-file test run: `npx vitest run <path>`. Full gate: `make ci`.
+
+---
+
+### Task 1: `STATUS_ORDER` constant + `filterGroupsByStatus` engine helper
+
+The core, pure, fully-tested filtering logic. Re-groups the kept assets via the existing `groupAssets`, so spans and ordering stay correct for the filtered subset.
+
+**Files:**
+- Modify: `src/utils/colors.ts` (add `STATUS_ORDER`)
+- Create: `src/engines/csv/statusFilter.ts`
+- Test: `src/engines/csv/__tests__/statusFilter.test.ts`
+
+**Interfaces:**
+- Consumes: `groupAssets` (`src/engines/csv/assetGrouper.ts`), `contractStatus` (`src/utils/colors.ts`), `ContractStatus`/`LocationGroup`/`ParsedAsset` (`src/types/asset.ts`).
+- Produces:
+  - `STATUS_ORDER: ContractStatus[]` = `['ok','warning','critical','expired']` (canonical ordered full set).
+  - `filterGroupsByStatus(groups: LocationGroup[], statuses: ContractStatus[]): LocationGroup[]` — returns `groups` unchanged when all statuses are present; `[]` when `statuses` is empty.
+
+- [ ] **Step 1: Add `STATUS_ORDER` to `src/utils/colors.ts`**
+
+Append after the existing `STATUS_COLORS` export:
+
+```ts
+/** Canonical ordered list of all contract-status buckets (widest scope first). */
+export const STATUS_ORDER: ContractStatus[] = ['ok', 'warning', 'critical', 'expired']
+```
+
+(`ContractStatus` is already imported at the top of `colors.ts`.)
+
+- [ ] **Step 2: Write the failing test** — create `src/engines/csv/__tests__/statusFilter.test.ts`:
+
+```ts
+import { filterGroupsByStatus } from '../statusFilter'
+import { groupAssets } from '../assetGrouper'
+import { STATUS_ORDER } from '@/utils/colors'
+import type { ParsedAsset } from '@/types/asset'
+
+// daysRemaining → status: ok ≥730, warning 365–729, critical 0–364, expired <0
+function makeAsset(over: Partial<ParsedAsset> = {}): ParsedAsset {
+  const contractEnd = over.contractEnd ?? new Date(2027, 0, 1)
+  return {
+    assetId: 'A',
+    productName: 'P',
+    locationId: 'L1',
+    locationName: 'DC',
+    city: '',
+    country: '',
+    installDate: new Date(2022, 0, 1),
+    contractEnd,
+    daysRemaining: 1000,
+    endOfSupport: null,
+    barEnd: contractEnd,
+    ...over,
+  }
+}
+
+const okA = makeAsset({ assetId: 'OK', locationId: 'L1', daysRemaining: 1000 })
+const expA = makeAsset({ assetId: 'EXP', locationId: 'L1', daysRemaining: -50 })
+const critA = makeAsset({ assetId: 'CRIT', locationId: 'L2', daysRemaining: 100 })
+const groups = groupAssets([okA, expA, critA])
+
+function assetIds(gs: ReturnType<typeof groupAssets>): string[] {
+  return gs.flatMap((g) => g.productGroups.flatMap((pg) => pg.assets.map((a) => a.assetId))).sort()
+}
+
+describe('filterGroupsByStatus', () => {
+  it('returns the input unchanged when all statuses are visible', () => {
+    expect(filterGroupsByStatus(groups, STATUS_ORDER)).toBe(groups)
+  })
+
+  it('keeps only expired assets and drops emptied groups/locations', () => {
+    const out = filterGroupsByStatus(groups, ['expired'])
+    expect(assetIds(out)).toEqual(['EXP'])
+    expect(out).toHaveLength(1) // only L1 survives
+  })
+
+  it('keeps a multi-status selection across locations', () => {
+    const out = filterGroupsByStatus(groups, ['ok', 'critical'])
+    expect(assetIds(out)).toEqual(['CRIT', 'OK'])
+    expect(out.map((g) => g.locationId).sort()).toEqual(['L1', 'L2'])
+  })
+
+  it('returns an empty array when no statuses are visible', () => {
+    expect(filterGroupsByStatus(groups, [])).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run src/engines/csv/__tests__/statusFilter.test.ts`
+Expected: FAIL — `../statusFilter` does not exist (module not found).
+
+- [ ] **Step 4: Implement** — create `src/engines/csv/statusFilter.ts`:
+
+```ts
+import type { ContractStatus, LocationGroup } from '@/types/asset'
+import { STATUS_ORDER, contractStatus } from '@/utils/colors'
+import { groupAssets } from './assetGrouper'
+
+/**
+ * Keep only assets whose contract status is in `statuses`, then re-group so summary
+ * spans and ordering are recomputed for the filtered subset. Returns the input
+ * unchanged when all statuses are visible (no-op fast path); returns [] when
+ * `statuses` is empty. `statuses` is assumed to hold unique members of STATUS_ORDER.
+ */
+export function filterGroupsByStatus(
+  groups: LocationGroup[],
+  statuses: ContractStatus[],
+): LocationGroup[] {
+  if (statuses.length >= STATUS_ORDER.length) return groups
+  const kept = groups
+    .flatMap((g) => g.productGroups.flatMap((pg) => pg.assets))
+    .filter((a) => statuses.includes(contractStatus(a.daysRemaining)))
+  return groupAssets(kept)
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/engines/csv/__tests__/statusFilter.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Run lint + typecheck**
+
+Run: `make lint && make typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/colors.ts src/engines/csv/statusFilter.ts src/engines/csv/__tests__/statusFilter.test.ts
+git commit   # "feat: add STATUS_ORDER + filterGroupsByStatus engine helper" + required trailers
+```
+
+---
+
+### Task 2: Store `statuses` field + GanttPanel wiring
+
+Add the visible-status set to the store (default all four) and insert the helper into the GanttPanel filter pipeline. After this task the plumbing is live but behavior is unchanged (default = all visible = no-op).
+
+**Files:**
+- Modify: `src/store/assetStore.ts` (`Filters` interface lines 5-10; `initialState.filters` line 65)
+- Modify: `src/components/outputs/GanttPanel.tsx` (imports; filter pipeline lines 18-34)
+- Test: `src/store/__tests__/assetStore.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `STATUS_ORDER` and `filterGroupsByStatus` from Task 1; `ContractStatus` (`src/types/asset.ts`).
+- Produces: `Filters.statuses: ContractStatus[]` (the visible set); store default `[...STATUS_ORDER]`.
+
+- [ ] **Step 1: Write the failing store test** — create `src/store/__tests__/assetStore.test.ts`:
+
+```ts
+import { useAssetStore } from '@store/assetStore'
+import { STATUS_ORDER } from '@utils/colors'
+
+describe('assetStore status filter state', () => {
+  beforeEach(() => {
+    useAssetStore.getState().reset()
+  })
+
+  it('defaults filters.statuses to all status buckets', () => {
+    expect(useAssetStore.getState().filters.statuses).toEqual(STATUS_ORDER)
+  })
+
+  it('merges statuses via setFilters without dropping other filters', () => {
+    useAssetStore.getState().setFilters({ search: 'foo' })
+    useAssetStore.getState().setFilters({ statuses: ['expired'] })
+    const f = useAssetStore.getState().filters
+    expect(f.statuses).toEqual(['expired'])
+    expect(f.search).toBe('foo')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/store/__tests__/assetStore.test.ts`
+Expected: FAIL — `filters.statuses` is `undefined` (and a TS error that `statuses` is not on `Filters`).
+
+- [ ] **Step 3: Add `statuses` to the store** — in `src/store/assetStore.ts`:
+
+Change the imports on line 3 from:
+```ts
+import type { LocationGroup } from '@/types/asset'
+```
+to:
+```ts
+import type { ContractStatus, LocationGroup } from '@/types/asset'
+import { STATUS_ORDER } from '@/utils/colors'
+```
+
+Extend the `Filters` interface (lines 5-10) to add the `statuses` field:
+```ts
+export interface Filters {
+  /** Location IDs to show; empty = show all */
+  locationIds: string[]
+  /** Free text search on product name */
+  search: string
+  /** Contract-status buckets currently visible. Defaults to all of STATUS_ORDER. */
+  statuses: ContractStatus[]
+}
+```
+
+Update `initialState.filters` (line 65) from:
+```ts
+  filters: { locationIds: [], search: '' },
+```
+to:
+```ts
+  filters: { locationIds: [], search: '', statuses: [...STATUS_ORDER] },
+```
+
+- [ ] **Step 4: Run the store test to verify it passes**
+
+Run: `npx vitest run src/store/__tests__/assetStore.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire the helper into `src/components/outputs/GanttPanel.tsx`**
+
+Add imports (after line 5, alongside the existing `toGanttData` import):
+```ts
+import { filterGroupsByStatus } from '@engines/csv/statusFilter'
+import { STATUS_ORDER } from '@utils/colors'
+```
+
+Replace the Step 1 + Step 2 block (lines 23-31) with:
+```ts
+  // Step 1: filter by location using string IDs from locationGroups
+  const locationFiltered =
+    filters.locationIds.length > 0
+      ? locationGroups.filter((g) => filters.locationIds.includes(g.locationId))
+      : locationGroups
+
+  // Step 2: filter by contract status (no-op when all buckets are visible)
+  const statusActive = filters.statuses.length < STATUS_ORDER.length
+  const statusFiltered = statusActive
+    ? filterGroupsByStatus(locationFiltered, filters.statuses)
+    : locationFiltered
+
+  // Step 3: derive base tasks (recompute only when a location or status filter is active)
+  const baseTasks =
+    filters.locationIds.length > 0 || statusActive
+      ? toGanttData(statusFiltered).tasks
+      : ganttData.tasks
+```
+
+(The existing `// Step 3` text-search line — now Step 4 conceptually — stays unchanged: `const tasks = filters.search ? applySearchFilter(baseTasks, filters.search) : baseTasks`.)
+
+- [ ] **Step 6: Typecheck + lint + full suite**
+
+Run: `make typecheck && make lint && npx vitest run`
+Expected: all pass (the new store test green; existing suite unaffected; GanttPanel compiles with the new imports).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/assetStore.ts src/components/outputs/GanttPanel.tsx src/store/__tests__/assetStore.test.ts
+git commit   # "feat: wire contract-status filter into store + GanttPanel" + required trailers
+```
+
+---
+
+### Task 3: Interactive legend (FilterPanel) + i18n keys
+
+Turn the static legend rows into toggle buttons and add the two new i18n keys to all four locales. Completes the feature.
+
+**Files:**
+- Modify: `src/components/inputs/FilterPanel.tsx`
+- Modify: `src/i18n/locales/en.json`, `fr.json`, `it.json`, `de.json`
+- Test: `src/i18n/__tests__/locales.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `STATUS_ORDER` and `STATUS_COLORS` (`src/utils/colors.ts`); `filters.statuses` + `setFilters` (store, Task 2); `ContractStatus` (`src/types/asset.ts`).
+- Produces: no new exports (UI + locale data).
+
+- [ ] **Step 1: Write the failing locale-completeness test** — create `src/i18n/__tests__/locales.test.ts`:
+
+```ts
+import de from '../locales/de.json'
+import en from '../locales/en.json'
+import fr from '../locales/fr.json'
+import it from '../locales/it.json'
+
+const locales: Record<string, { filter: Record<string, string> }> = { en, fr, it, de }
+
+describe('locale completeness for the legend filter', () => {
+  for (const [name, dict] of Object.entries(locales)) {
+    it(`${name} defines filter.legend and filter.showAll`, () => {
+      expect(dict.filter.legend).toBeTruthy()
+      expect(dict.filter.showAll).toBeTruthy()
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/i18n/__tests__/locales.test.ts`
+Expected: FAIL — `filter.legend` / `filter.showAll` are `undefined` in all four locales.
+
+- [ ] **Step 3: Add the two keys to each locale's `filter` object**
+
+In each file, add `legend` and `showAll` to the existing `filter` object (e.g. after its `clear` entry), matching the file's existing indentation:
+
+- `src/i18n/locales/en.json` → `"legend": "Legend", "showAll": "Show all"`
+- `src/i18n/locales/fr.json` → `"legend": "Légende", "showAll": "Tout afficher"`
+- `src/i18n/locales/it.json` → `"legend": "Legenda", "showAll": "Mostra tutto"`
+- `src/i18n/locales/de.json` → `"legend": "Legende", "showAll": "Alle anzeigen"`
+
+- [ ] **Step 4: Run the locale test to verify it passes**
+
+Run: `npx vitest run src/i18n/__tests__/locales.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Make the legend interactive** — in `src/components/inputs/FilterPanel.tsx`:
+
+Update the colors import (line 3) to also bring in `STATUS_ORDER`:
+```ts
+import { STATUS_COLORS, STATUS_ORDER } from '@utils/colors'
+```
+
+Replace the inline `statuses` array (lines 19-24) with a `STATUS_ORDER`-driven list plus a toggle handler:
+```ts
+  const statusItems = STATUS_ORDER.map((status) => ({ status, label: t(`status.${status}`) }))
+
+  const toggleStatus = (s: ContractStatus) => {
+    const cur = filters.statuses
+    setFilters({ statuses: cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s] })
+  }
+```
+
+Replace the whole `{/* Legend */}` block (lines 79-95) with an interactive version:
+```tsx
+      {/* Legend — click a row to show/hide that status bucket */}
+      <div>
+        <div className="mb-1 flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('filter.legend')}
+          </p>
+          {filters.statuses.length < STATUS_ORDER.length && (
+            <button
+              type="button"
+              onClick={() => setFilters({ statuses: [...STATUS_ORDER] })}
+              className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {t('filter.showAll')}
+            </button>
+          )}
+        </div>
+        <div className="space-y-1">
+          {statusItems.map(({ status, label }) => {
+            const visible = filters.statuses.includes(status)
+            return (
+              <button
+                key={status}
+                type="button"
+                aria-pressed={visible}
+                onClick={() => toggleStatus(status)}
+                className={`flex w-full items-center gap-2 text-xs ${
+                  visible
+                    ? 'text-gray-600 dark:text-gray-300'
+                    : 'text-gray-400 line-through opacity-50 dark:text-gray-500'
+                }`}
+              >
+                <span
+                  className="inline-block h-3 w-3 flex-shrink-0 rounded-sm"
+                  style={{ backgroundColor: STATUS_COLORS[status] }}
+                />
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+```
+
+(`ContractStatus` is already imported in `FilterPanel.tsx` at line 4; `filters`/`setFilters` already destructured from the store at line 8.)
+
+- [ ] **Step 6: Full CI gate**
+
+Run: `make ci`
+Expected: typecheck + lint + test-coverage (≥75% on engines/utils) + build all pass.
+
+- [ ] **Step 7: Manual smoke check**
+
+Run: `make dev`, open `http://localhost:5173/360gantt/`, load any CSV (e.g. `~/Library/CloudStorage/OneDrive-Home/assets (7).csv`). Verify:
+- All four legend rows are clickable; clicking "Expired" hides expired (gray) bars and dims/strikes that legend row; clicking again restores them.
+- "Show all" appears when any bucket is hidden and restores all four.
+- Status filter composes with location + search filters.
+- Toggling all four off yields an empty chart.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/inputs/FilterPanel.tsx src/i18n/locales/*.json src/i18n/__tests__/locales.test.ts
+git commit   # "feat: interactive legend toggles contract-status filter" + required trailers
+```
+
+---
+
+## Verification (end-to-end)
+
+- [ ] `make ci` passes (typecheck, Biome, Vitest coverage ≥75% on engines/utils, build).
+- [ ] Manual smoke per Task 3 Step 7 (the one thing automation can't cover — legend interaction, dimming, empty state).
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Decision 1 (4 buckets) → `STATUS_ORDER` + legend maps it (Tasks 1, 3). Decision 2 (classic toggle, default all) → store default `[...STATUS_ORDER]` + `toggleStatus` (Tasks 2, 3). Decision 3 (hide not dim) → `filterGroupsByStatus` prunes + dimmed legend row (Tasks 1, 3). Decision 4 (all-hidden = empty) → helper returns `[]` for empty `statuses` (Task 1, tested). Decision 5 (composition) → GanttPanel pipeline ANDs location → status → search (Task 2). Store field, engine helper, GanttPanel wiring, interactive legend, i18n (4 locales) all have tasks. Spec's "reset on data load" note resolved: `setData` does not reset filters; default lives in `initialState` and is restored by `reset()`.
+- **Placeholders:** none — every code step shows full content.
+- **Type consistency:** `STATUS_ORDER: ContractStatus[]` and `filterGroupsByStatus(groups, statuses)` defined in Task 1 are consumed with identical names/types in Tasks 2-3; `Filters.statuses: ContractStatus[]` defined in Task 2 is read in Task 3; `STATUS_ORDER.length` used for the bucket count everywhere (no literal `4`).

--- a/docs/superpowers/specs/2026-06-24-legend-status-filter-design.md
+++ b/docs/superpowers/specs/2026-06-24-legend-status-filter-design.md
@@ -1,0 +1,155 @@
+# Filter the Gantt by contract status via an interactive legend
+
+**Date:** 2026-06-24
+**Status:** Approved (design)
+**Area:** `src/store/assetStore.ts`, `src/components/inputs/FilterPanel.tsx`,
+`src/components/outputs/GanttPanel.tsx`, new `src/engines/csv/statusFilter.ts`,
+i18n locale files.
+
+## Problem / goal
+
+Since v1.2.0 the Gantt shows all hardware regardless of contract status, including
+lapsed (gray/`expired`) contracts. Users now want to focus the view — e.g. "only
+active" or "only expired" — by toggling contract-status buckets. `FilterPanel.tsx`
+already renders a static **Legend** of the four status buckets; the goal is to make
+that legend interactive so it doubles as a status filter.
+
+## Background (existing code)
+
+- **`ContractStatus`** (`src/types/asset.ts`): `'ok' | 'warning' | 'critical' | 'expired'`.
+- **`contractStatus(daysRemaining)`** (`src/utils/colors.ts`): `< 0 → expired`,
+  `< 365 → critical`, `< 730 → warning`, else `ok`. `STATUS_COLORS` maps each to a hex.
+  This is the single source of truth for a bar's bucket (the same function backs the
+  bar color via `contractStatusColor`).
+- **Store filters** (`src/store/assetStore.ts`): `Filters = { locationIds: string[], search: string }`;
+  `setFilters(partial)` shallow-merges.
+- **Filter pipeline** (`src/components/outputs/GanttPanel.tsx`): (1) filter
+  `locationGroups` by `locationIds`; (2) when a location filter is active, recompute
+  `toGanttData(visibleGroups).tasks`, else use cached `ganttData.tasks`; (3)
+  `applySearchFilter(tasks, search)` prunes the 3-level task tree by text, preserving
+  non-empty parents.
+- **Legend** (`FilterPanel.tsx` lines 79–95): static rows of `STATUS_COLORS[status]`
+  swatch + `t('status.*')` label. The heading text `"Legend"` is currently hardcoded.
+- **Location filter convention**: "none selected = all shown" (checkbox `checked` when
+  `locationIds.length === 0 || includes(id)`), with a "Clear" link.
+
+## Decisions
+
+1. **Granularity:** toggle the **4 existing legend buckets** (`ok` / `warning` /
+   `critical` / `expired`), not a simpler Active/Expired binary. Filter and legend
+   stay in sync. "Active only" = leave the three non-expired on; "Expired only" = the
+   reverse.
+2. **Toggle model:** **classic legend toggle.** All four visible by default; clicking
+   a legend row **hides** that bucket, clicking again restores it. (Different from the
+   location filter's "empty = all" sentinel — the legend is a different affordance and
+   the chart-legend convention is more intuitive here.)
+3. **Hide, not dim:** hidden buckets are removed from the chart (consistent with how
+   location/search filters prune). The legend row for a hidden bucket is shown
+   dimmed/struck-through so its state is visible.
+4. **All-hidden is allowed:** toggling all four off yields an empty result (same
+   behavior as location/search filters that match nothing) — the last toggle is not
+   blocked.
+5. **Composition:** the status filter ANDs with the location and search filters.
+
+## Design
+
+### 1. Store (`src/store/assetStore.ts`)
+
+- Extend `Filters`:
+  ```ts
+  export interface Filters {
+    locationIds: string[]
+    search: string
+    /** Contract-status buckets currently VISIBLE. Defaults to all four. */
+    statuses: ContractStatus[]
+  }
+  ```
+- Default state: `{ locationIds: [], search: '', statuses: ['ok', 'warning', 'critical', 'expired'] }`.
+- Toggling reuses the existing `setFilters` partial-merge (no new store action needed).
+- Wherever filters are reset when new CSV data loads (the same place `locationIds`/
+  `search` reset), reset `statuses` to all four. (Confirm the exact reset site during
+  planning — likely `setData`.)
+
+### 2. Engine helper (`src/engines/csv/statusFilter.ts`, new)
+
+A pure, unit-tested function — the only new logic. It operates on `LocationGroup[]`
+(which carries `daysRemaining`), since the flattened `GanttTask` only has `color`.
+
+```ts
+import type { ContractStatus, LocationGroup } from '@/types/asset'
+import { contractStatus } from '@/utils/colors'
+import { groupAssets } from './assetGrouper'
+
+const STATUS_COUNT = 4
+
+/**
+ * Keep only assets whose contract status is in `statuses`, then re-group so spans
+ * and ordering are correct for the filtered subset. Returns the input unchanged when
+ * all four statuses are visible (no-op fast path); returns [] when `statuses` is empty.
+ */
+export function filterGroupsByStatus(
+  groups: LocationGroup[],
+  statuses: ContractStatus[],
+): LocationGroup[] {
+  if (statuses.length >= STATUS_COUNT) return groups
+  const kept = groups
+    .flatMap((g) => g.productGroups.flatMap((pg) => pg.assets))
+    .filter((a) => statuses.includes(contractStatus(a.daysRemaining)))
+  return groupAssets(kept)
+}
+```
+
+Re-running `groupAssets` (already tested) recomputes `groupStart/End`,
+`locationStart/End`, and sort order for the remaining assets — so a filtered view has
+correct summary spans and urgency ordering, with no duplicated grouping logic.
+
+### 3. GanttPanel pipeline (`src/components/outputs/GanttPanel.tsx`)
+
+Insert the status filter between the location filter and `toGanttData`:
+
+- `locationFiltered = filters.locationIds.length > 0 ? locationGroups.filter(...) : locationGroups`
+- `statusActive = filters.statuses.length < 4`
+- `statusFiltered = statusActive ? filterGroupsByStatus(locationFiltered, filters.statuses) : locationFiltered`
+- `baseTasks = (filters.locationIds.length > 0 || statusActive) ? toGanttData(statusFiltered).tasks : ganttData.tasks`
+- `tasks = filters.search ? applySearchFilter(baseTasks, filters.search) : baseTasks`
+
+So `toGanttData` is recomputed when **either** the location or status filter is active
+(today it's only the location filter). `applySearchFilter` is unchanged.
+
+### 4. FilterPanel legend (`src/components/inputs/FilterPanel.tsx`)
+
+- Convert each legend row from a `<div>` into a keyboard-accessible `<button>` with
+  `aria-pressed={isVisible}`, calling `toggleStatus(status)`:
+  ```ts
+  const toggleStatus = (s: ContractStatus) => {
+    const cur = filters.statuses
+    setFilters({ statuses: cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s] })
+  }
+  ```
+- A row whose status is **not** in `filters.statuses` renders dimmed (reduced opacity)
+  with a line-through label; the swatch keeps its color but fades.
+- Add a **"Show all"** link (shown only when `filters.statuses.length < 4`) that sets
+  `statuses` back to all four — mirroring the locations "Clear" link.
+- i18n: replace the hardcoded `"Legend"` heading with `t('filter.legend')`; add
+  `t('filter.showAll')`. Status labels (`status.*`) already exist. Add the new keys to
+  every locale file that defines `filter.*`/`status.*`.
+
+## Testing
+
+- **`statusFilter.test.ts`** (engine, pure):
+  - all four statuses → identity (same reference / same groups).
+  - a single status → keeps only matching assets; drops emptied product groups and
+    locations; spans/order recomputed (assert via re-grouped output).
+  - empty `statuses` → `[]`.
+  - mixed selection across multiple locations → correct surviving counts.
+- Coverage ≥ 75 % on the engine layer is maintained (the new file is pure and fully
+  covered).
+- The GanttPanel wiring is thin (delegates to the helper); covered indirectly by the
+  helper tests plus the existing pipeline behavior.
+
+## Out of scope
+
+- Persisting filter state across reloads.
+- Animating bar show/hide.
+- Per-status asset **counts** in the legend.
+- Moving the existing inline `applySearchFilter` into the engine layer (unrelated).

--- a/src/components/inputs/FilterPanel.tsx
+++ b/src/components/inputs/FilterPanel.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useAssetStore } from '@store/assetStore'
-import { STATUS_COLORS } from '@utils/colors'
+import { STATUS_COLORS, STATUS_ORDER } from '@utils/colors'
 import type { ContractStatus } from '@/types/asset'
 
 export function FilterPanel() {
@@ -16,12 +16,12 @@ export function FilterPanel() {
     setFilters({ locationIds: next })
   }
 
-  const statuses: { status: ContractStatus; label: string }[] = [
-    { status: 'ok', label: t('status.ok') },
-    { status: 'warning', label: t('status.warning') },
-    { status: 'critical', label: t('status.critical') },
-    { status: 'expired', label: t('status.expired') },
-  ]
+  const statusItems = STATUS_ORDER.map((status) => ({ status, label: t(`status.${status}`) }))
+
+  const toggleStatus = (s: ContractStatus) => {
+    const cur = filters.statuses
+    setFilters({ statuses: cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s] })
+  }
 
   return (
     <div className="space-y-4">
@@ -76,21 +76,45 @@ export function FilterPanel() {
         </div>
       </div>
 
-      {/* Legend */}
+      {/* Legend — click a row to show/hide that status bucket */}
       <div>
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-          Legend
-        </p>
+        <div className="mb-1 flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('filter.legend')}
+          </p>
+          {filters.statuses.length < STATUS_ORDER.length && (
+            <button
+              type="button"
+              onClick={() => setFilters({ statuses: [...STATUS_ORDER] })}
+              className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {t('filter.showAll')}
+            </button>
+          )}
+        </div>
         <div className="space-y-1">
-          {statuses.map(({ status, label }) => (
-            <div key={status} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
-              <span
-                className="inline-block h-3 w-3 flex-shrink-0 rounded-sm"
-                style={{ backgroundColor: STATUS_COLORS[status] }}
-              />
-              {label}
-            </div>
-          ))}
+          {statusItems.map(({ status, label }) => {
+            const visible = filters.statuses.includes(status)
+            return (
+              <button
+                key={status}
+                type="button"
+                aria-pressed={visible}
+                onClick={() => toggleStatus(status)}
+                className={`flex w-full items-center gap-2 text-xs ${
+                  visible
+                    ? 'text-gray-600 dark:text-gray-300'
+                    : 'text-gray-400 line-through opacity-50 dark:text-gray-500'
+                }`}
+              >
+                <span
+                  className="inline-block h-3 w-3 flex-shrink-0 rounded-sm"
+                  style={{ backgroundColor: STATUS_COLORS[status] }}
+                />
+                {label}
+              </button>
+            )
+          })}
         </div>
       </div>
     </div>

--- a/src/components/outputs/GanttPanel.tsx
+++ b/src/components/outputs/GanttPanel.tsx
@@ -3,6 +3,8 @@ import type { CSSProperties } from 'react'
 import { SCALE_STEPS, ZOOM_PRESETS, useAssetStore } from '@store/assetStore'
 import { useDarkMode } from '@hooks/useDarkMode'
 import { toGanttData } from '@engines/csv/svarAdapter'
+import { filterGroupsByStatus } from '@engines/csv/statusFilter'
+import { STATUS_ORDER } from '@utils/colors'
 import type { GanttTask } from '@/types/gantt'
 import { SvgGantt } from './gantt'
 
@@ -21,16 +23,24 @@ export const GanttPanel = forwardRef<HTMLDivElement, GanttPanelProps>(function G
   const cssZoom = SCALE_STEPS[scaleIdx] ?? 1
 
   // Step 1: filter by location using string IDs from locationGroups
-  const visibleGroups =
+  const locationFiltered =
     filters.locationIds.length > 0
       ? locationGroups.filter((g) => filters.locationIds.includes(g.locationId))
       : locationGroups
 
-  // Step 2: derive base tasks (recompute only when location filter is active)
-  const baseTasks =
-    filters.locationIds.length > 0 ? toGanttData(visibleGroups).tasks : ganttData.tasks
+  // Step 2: filter by contract status (no-op when all buckets are visible)
+  const statusActive = filters.statuses.length < STATUS_ORDER.length
+  const statusFiltered = statusActive
+    ? filterGroupsByStatus(locationFiltered, filters.statuses)
+    : locationFiltered
 
-  // Step 3: apply text search on the already-location-filtered flat task list
+  // Step 3: derive base tasks (recompute only when a location or status filter is active)
+  const baseTasks =
+    filters.locationIds.length > 0 || statusActive
+      ? toGanttData(statusFiltered).tasks
+      : ganttData.tasks
+
+  // Step 4: apply text search on the already-location-filtered flat task list
   const tasks = filters.search ? applySearchFilter(baseTasks, filters.search) : baseTasks
 
   return (

--- a/src/engines/csv/__tests__/statusFilter.test.ts
+++ b/src/engines/csv/__tests__/statusFilter.test.ts
@@ -1,0 +1,54 @@
+import { filterGroupsByStatus } from '../statusFilter'
+import { groupAssets } from '../assetGrouper'
+import { STATUS_ORDER } from '@/utils/colors'
+import type { ParsedAsset } from '@/types/asset'
+
+// daysRemaining → status: ok ≥730, warning 365–729, critical 0–364, expired <0
+function makeAsset(over: Partial<ParsedAsset> = {}): ParsedAsset {
+  const contractEnd = over.contractEnd ?? new Date(2027, 0, 1)
+  return {
+    assetId: 'A',
+    productName: 'P',
+    locationId: 'L1',
+    locationName: 'DC',
+    city: '',
+    country: '',
+    installDate: new Date(2022, 0, 1),
+    contractEnd,
+    daysRemaining: 1000,
+    endOfSupport: null,
+    barEnd: contractEnd,
+    ...over,
+  }
+}
+
+const okA = makeAsset({ assetId: 'OK', locationId: 'L1', daysRemaining: 1000 })
+const expA = makeAsset({ assetId: 'EXP', locationId: 'L1', daysRemaining: -50 })
+const critA = makeAsset({ assetId: 'CRIT', locationId: 'L2', daysRemaining: 100 })
+const groups = groupAssets([okA, expA, critA])
+
+function assetIds(gs: ReturnType<typeof groupAssets>): string[] {
+  return gs.flatMap((g) => g.productGroups.flatMap((pg) => pg.assets.map((a) => a.assetId))).sort()
+}
+
+describe('filterGroupsByStatus', () => {
+  it('returns the input unchanged when all statuses are visible', () => {
+    expect(filterGroupsByStatus(groups, STATUS_ORDER)).toBe(groups)
+  })
+
+  it('keeps only expired assets and drops emptied groups/locations', () => {
+    const out = filterGroupsByStatus(groups, ['expired'])
+    expect(assetIds(out)).toEqual(['EXP'])
+    expect(out).toHaveLength(1) // only L1 survives
+  })
+
+  it('keeps a multi-status selection across locations', () => {
+    const out = filterGroupsByStatus(groups, ['ok', 'critical'])
+    expect(assetIds(out)).toEqual(['CRIT', 'OK'])
+    expect(out.map((g) => g.locationId).sort()).toEqual(['L1', 'L2'])
+  })
+
+  it('returns an empty array when no statuses are visible', () => {
+    expect(filterGroupsByStatus(groups, [])).toEqual([])
+  })
+})

--- a/src/engines/csv/__tests__/statusFilter.test.ts
+++ b/src/engines/csv/__tests__/statusFilter.test.ts
@@ -25,7 +25,8 @@ function makeAsset(over: Partial<ParsedAsset> = {}): ParsedAsset {
 const okA = makeAsset({ assetId: 'OK', locationId: 'L1', daysRemaining: 1000 })
 const expA = makeAsset({ assetId: 'EXP', locationId: 'L1', daysRemaining: -50 })
 const critA = makeAsset({ assetId: 'CRIT', locationId: 'L2', daysRemaining: 100 })
-const groups = groupAssets([okA, expA, critA])
+const warnA = makeAsset({ assetId: 'WARN', locationId: 'L3', daysRemaining: 500 })
+const groups = groupAssets([okA, expA, critA, warnA])
 
 function assetIds(gs: ReturnType<typeof groupAssets>): string[] {
   return gs.flatMap((g) => g.productGroups.flatMap((pg) => pg.assets.map((a) => a.assetId))).sort()
@@ -50,5 +51,10 @@ describe('filterGroupsByStatus', () => {
 
   it('returns an empty array when no statuses are visible', () => {
     expect(filterGroupsByStatus(groups, [])).toEqual([])
+  })
+
+  it('keeps only warning-bucket assets when filtered to warning', () => {
+    const out = filterGroupsByStatus(groups, ['warning'])
+    expect(assetIds(out)).toEqual(['WARN'])
   })
 })

--- a/src/engines/csv/statusFilter.ts
+++ b/src/engines/csv/statusFilter.ts
@@ -1,0 +1,20 @@
+import type { ContractStatus, LocationGroup } from '@/types/asset'
+import { STATUS_ORDER, contractStatus } from '@/utils/colors'
+import { groupAssets } from './assetGrouper'
+
+/**
+ * Keep only assets whose contract status is in `statuses`, then re-group so summary
+ * spans and ordering are recomputed for the filtered subset. Returns the input
+ * unchanged when all statuses are visible (no-op fast path); returns [] when
+ * `statuses` is empty. `statuses` is assumed to hold unique members of STATUS_ORDER.
+ */
+export function filterGroupsByStatus(
+  groups: LocationGroup[],
+  statuses: ContractStatus[],
+): LocationGroup[] {
+  if (statuses.length >= STATUS_ORDER.length) return groups
+  const kept = groups
+    .flatMap((g) => g.productGroups.flatMap((pg) => pg.assets))
+    .filter((a) => statuses.includes(contractStatus(a.daysRemaining)))
+  return groupAssets(kept)
+}

--- a/src/i18n/__tests__/locales.test.ts
+++ b/src/i18n/__tests__/locales.test.ts
@@ -1,0 +1,15 @@
+import de from '../locales/de.json'
+import en from '../locales/en.json'
+import fr from '../locales/fr.json'
+import itLocale from '../locales/it.json'
+
+const locales: Record<string, { filter: Record<string, string> }> = { en, fr, it: itLocale, de }
+
+describe('locale completeness for the legend filter', () => {
+  for (const [name, dict] of Object.entries(locales)) {
+    it(`${name} defines filter.legend and filter.showAll`, () => {
+      expect(dict.filter.legend).toBeTruthy()
+      expect(dict.filter.showAll).toBeTruthy()
+    })
+  }
+})

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -19,7 +19,9 @@
     "search": "Produkte suchen…",
     "locations": "Standorte",
     "allLocations": "Alle Standorte",
-    "clear": "Filter zurücksetzen"
+    "clear": "Filter zurücksetzen",
+    "legend": "Legende",
+    "showAll": "Alle anzeigen"
   },
   "gantt": {
     "noData": "Laden Sie eine CSV-Datei, um das Gantt-Diagramm anzuzeigen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -19,7 +19,9 @@
     "search": "Search products…",
     "locations": "Locations",
     "allLocations": "All locations",
-    "clear": "Clear filters"
+    "clear": "Clear filters",
+    "legend": "Legend",
+    "showAll": "Show all"
   },
   "gantt": {
     "noData": "Load a CSV file to see the Gantt chart",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -19,7 +19,9 @@
     "search": "Rechercher des produits…",
     "locations": "Sites",
     "allLocations": "Tous les sites",
-    "clear": "Effacer les filtres"
+    "clear": "Effacer les filtres",
+    "legend": "Légende",
+    "showAll": "Tout afficher"
   },
   "gantt": {
     "noData": "Chargez un fichier CSV pour afficher le diagramme de Gantt",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -19,7 +19,9 @@
     "search": "Cerca prodotti…",
     "locations": "Sedi",
     "allLocations": "Tutte le sedi",
-    "clear": "Cancella filtri"
+    "clear": "Cancella filtri",
+    "legend": "Legenda",
+    "showAll": "Mostra tutto"
   },
   "gantt": {
     "noData": "Carica un file CSV per visualizzare il diagramma di Gantt",

--- a/src/store/__tests__/assetStore.test.ts
+++ b/src/store/__tests__/assetStore.test.ts
@@ -1,0 +1,20 @@
+import { useAssetStore } from '@store/assetStore'
+import { STATUS_ORDER } from '@utils/colors'
+
+describe('assetStore status filter state', () => {
+  beforeEach(() => {
+    useAssetStore.getState().reset()
+  })
+
+  it('defaults filters.statuses to all status buckets', () => {
+    expect(useAssetStore.getState().filters.statuses).toEqual(STATUS_ORDER)
+  })
+
+  it('merges statuses via setFilters without dropping other filters', () => {
+    useAssetStore.getState().setFilters({ search: 'foo' })
+    useAssetStore.getState().setFilters({ statuses: ['expired'] })
+    const f = useAssetStore.getState().filters
+    expect(f.statuses).toEqual(['expired'])
+    expect(f.search).toBe('foo')
+  })
+})

--- a/src/store/__tests__/assetStore.test.ts
+++ b/src/store/__tests__/assetStore.test.ts
@@ -17,4 +17,13 @@ describe('assetStore status filter state', () => {
     expect(f.statuses).toEqual(['expired'])
     expect(f.search).toBe('foo')
   })
+
+  it('resets filters when new data is loaded', () => {
+    useAssetStore.getState().setFilters({ statuses: ['expired'], search: 'foo', locationIds: ['L9'] })
+    useAssetStore.getState().setData([], { tasks: [], links: [] }, 0, 'new.csv')
+    const f = useAssetStore.getState().filters
+    expect(f.statuses).toEqual(STATUS_ORDER)
+    expect(f.search).toBe('')
+    expect(f.locationIds).toEqual([])
+  })
 })

--- a/src/store/assetStore.ts
+++ b/src/store/assetStore.ts
@@ -60,12 +60,18 @@ interface AssetState {
   reset: () => void
 }
 
+const makeInitialFilters = (): Filters => ({
+  locationIds: [],
+  search: '',
+  statuses: [...STATUS_ORDER],
+})
+
 const initialState = {
   loading: false,
   error: null,
   locationGroups: [],
   ganttData: { tasks: [], links: [] },
-  filters: { locationIds: [], search: '', statuses: [...STATUS_ORDER] },
+  filters: makeInitialFilters(),
   totalAssets: 0,
   fileName: null,
   zoomLevel: DEFAULT_ZOOM_IDX,
@@ -79,7 +85,15 @@ export const useAssetStore = create<AssetState>()((set, get) => ({
   setError: (error) => set({ error, loading: false }),
 
   setData: (locationGroups, ganttData, totalAssets, fileName) =>
-    set({ locationGroups, ganttData, totalAssets, fileName, error: null, loading: false }),
+    set({
+      locationGroups,
+      ganttData,
+      totalAssets,
+      fileName,
+      error: null,
+      loading: false,
+      filters: makeInitialFilters(),
+    }),
 
   setFilters: (partial) =>
     set((state) => ({ filters: { ...state.filters, ...partial } })),

--- a/src/store/assetStore.ts
+++ b/src/store/assetStore.ts
@@ -1,12 +1,15 @@
 import { create } from 'zustand'
 import type { GanttData } from '@/types/gantt'
-import type { LocationGroup } from '@/types/asset'
+import type { ContractStatus, LocationGroup } from '@/types/asset'
+import { STATUS_ORDER } from '@/utils/colors'
 
 export interface Filters {
   /** Location IDs to show; empty = show all */
   locationIds: string[]
   /** Free text search on product name */
   search: string
+  /** Contract-status buckets currently visible. Defaults to all of STATUS_ORDER. */
+  statuses: ContractStatus[]
 }
 
 /** Time-axis zoom presets (widest → finest) */
@@ -62,7 +65,7 @@ const initialState = {
   error: null,
   locationGroups: [],
   ganttData: { tasks: [], links: [] },
-  filters: { locationIds: [], search: '' },
+  filters: { locationIds: [], search: '', statuses: [...STATUS_ORDER] },
   totalAssets: 0,
   fileName: null,
   zoomLevel: DEFAULT_ZOOM_IDX,

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -21,3 +21,6 @@ export const STATUS_COLORS: Record<ContractStatus, string> = {
   critical: '#003B6F',
   expired: '#9ca3af',
 }
+
+/** Canonical ordered list of all contract-status buckets (widest scope first). */
+export const STATUS_ORDER: ContractStatus[] = ['ok', 'warning', 'critical', 'expired']


### PR DESCRIPTION
## What

Makes the existing `FilterPanel` legend interactive so users can focus the Gantt by **contract status**. The four legend buckets — OK / Warning / Critical / Expired — become toggle buttons: all visible by default; click one to hide that bucket's assets, click again to restore (classic chart-legend behavior). "Active only" = one click (hide Expired); "Expired only" = hide the other three.

Follows the v1.2.0 work that made lapsed contracts visible — now they're filterable.

## How

- **`STATUS_ORDER` + `filterGroupsByStatus`** (new pure engine helper, `src/engines/csv/statusFilter.ts`): keeps assets whose `contractStatus(daysRemaining)` is in the visible set, then re-runs `groupAssets` so summary spans and ordering stay correct for the filtered subset. No-op fast path (returns input unchanged) when all buckets are visible; `[]` when none are.
- **Store** (`Filters.statuses: ContractStatus[]`, default all buckets): the visible set; toggled via the existing `setFilters` partial-merge.
- **GanttPanel pipeline**: location filter → status filter → `toGanttData` → search filter. The status step is gated on `filters.statuses.length < STATUS_ORDER.length` (no magic `4`), so the default state is a true no-op.
- **Interactive legend** (`FilterPanel.tsx`): `STATUS_ORDER`-driven `<button>` toggles with `aria-pressed`; hidden buckets render dimmed + struck-through; a "Show all" link appears when any bucket is hidden. New i18n keys `filter.legend` / `filter.showAll` in **all four locales** (en/fr/it/de).

## Behavior note (from review)

Loading a new CSV now **resets all filters** (location + search + status) to defaults — stale filters from a previously-loaded file no longer carry over. This honors the spec's intent and is standard "fresh file → fresh view" UX; it slightly broadens reset behavior beyond the status filter itself.

## Testing

- TDD throughout; `make ci` green — **111 tests**, coverage 97.23% stmts / 89.18% branches / 97.91% funcs / 100% lines (threshold ≥75% on `engines`/`utils`).
- New tests: `filterGroupsByStatus` (identity fast-path by reference, single/multi/empty status, all four buckets incl. warning), store default + partial-merge + **reset-on-load**, and a locale-completeness guard asserting both new keys exist in all four locales.
- Engine helper is pure/fully covered; the FilterPanel UI is verified by typecheck/lint + manual smoke (the project has no component-test harness).

## Not yet done

- **Manual browser smoke** — interactive legend toggling, dimming, and the all-hidden empty state. Worth eyeballing before release (unit tests can't cover the rendered interaction).

## Docs

- Spec: `docs/superpowers/specs/2026-06-24-legend-status-filter-design.md`
- Plan: `docs/superpowers/plans/2026-06-24-legend-status-filter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Gantt legend is now interactive, letting you toggle contract-status buckets on and off and quickly show all statuses again.
  * Status filtering now works alongside location and search filters for more precise results.

* **Bug Fixes**
  * Filter selections now reset correctly when new data is loaded.
  * Empty and fully enabled status selections behave consistently.

* **Documentation**
  * Added updated design and implementation planning notes.

* **Tests**
  * Added coverage for status filtering, store reset behavior, and locale translation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->